### PR TITLE
Make API level and scheduling group count configurable

### DIFF
--- a/seastar/build.rs
+++ b/seastar/build.rs
@@ -30,14 +30,17 @@ fn main() {
         .map(|p| PathBuf::try_from(p).unwrap())
         .collect::<Vec<_>>();
 
-    // TODO: The API level and scheduling group count
-    // should be configurable somehow
-    cxx_build::bridges(&cxx_bridges)
+    let mut build = cxx_build::bridges(&cxx_bridges);
+    for (var, value) in &seastar.defines {
+        match value {
+            Some(val) => build.define(var, val.as_str()),
+            None => build.define(var, None),
+        };
+    }
+    build
         .flag_if_supported("-Wall")
         .flag_if_supported("-std=c++20")
         .flag_if_supported("-fcoroutines")
-        .define("SEASTAR_API_LEVEL", "6")
-        .define("SEASTAR_SCHEDULING_GROUPS_COUNT", "16")
         .includes(&seastar.include_paths)
         .compile("seastar-rs");
 

--- a/seastar/build.rs
+++ b/seastar/build.rs
@@ -42,6 +42,7 @@ fn main() {
         .flag_if_supported("-std=c++20")
         .flag_if_supported("-fcoroutines")
         .includes(&seastar.include_paths)
+        .cpp_link_stdlib("stdc++")
         .compile("seastar-rs");
 
     println!("cargo:rerun-if-changed=build.rs");

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -1,5 +1,5 @@
 //! Idiomatic bindings to the Seastar framework.
-//! 
+//!
 //! Work in progress! Definitely not for use in production yet.
 
 mod preempt;


### PR DESCRIPTION
Code added in this PR sets `SEASTAR_API_LEVEL` and `SEASTAR_SCHEDULING_GROUPS_COUNT` the way pkg_config would. Moreover, all other -D variables are also defined. It turned out to be really easy to implement. It's just a simple iteration over the elements of `seastar.defines`.

I also added `.cpp_link_stdlib("stdc++")` that will be necessary later.