### PR TITLE
Gate

### DIFF
--- a/seastar/Cargo.toml
+++ b/seastar/Cargo.toml
@@ -12,6 +12,7 @@ cxx-async = { git = "https://github.com/kfernandez31/cxx-async", branch = "seast
 futures = "0.3.25"
 pin-project = "1"
 seastar-macros = { path = "../seastar-macros" }
+thiserror = "1.0.38"
 
 [dev-dependencies]
 num_cpus = "1.15.0"

--- a/seastar/build.rs
+++ b/seastar/build.rs
@@ -7,6 +7,7 @@ static CXX_BRIDGES: &[&str] = &[
     "src/api_safety.rs",
     "src/spawn.rs",
     "src/submit_to.rs",
+    "src/gate.rs",
 ];
 
 static CXX_CPP_SOURCES: &[&str] = &[
@@ -14,6 +15,7 @@ static CXX_CPP_SOURCES: &[&str] = &[
     "src/config_and_start_seastar.cc",
     "src/spawn.cc",
     "src/submit_to.cc",
+    "src/gate.cc",
 ];
 
 fn main() {

--- a/seastar/src/gate.cc
+++ b/seastar/src/gate.cc
@@ -7,5 +7,9 @@ std::unique_ptr<gate> new_gate() {
     return std::make_unique<gate>();
 }
 
+std::unique_ptr<gate_holder> new_gate_holder(const std::unique_ptr<gate>& gate) {
+    return std::make_unique<gate_holder>(*gate);
+}
+
 } // namespace gate
 } // namespace seastar_ffi

--- a/seastar/src/gate.cc
+++ b/seastar/src/gate.cc
@@ -1,0 +1,7 @@
+#include "gate.hh"
+
+namespace seastar_ffi {
+namespace gate {
+
+} // namespace gate
+} // namespace seastar_ffi

--- a/seastar/src/gate.cc
+++ b/seastar/src/gate.cc
@@ -3,5 +3,9 @@
 namespace seastar_ffi {
 namespace gate {
 
+std::unique_ptr<gate> new_gate() {
+    return std::make_unique<gate>();
+}
+
 } // namespace gate
 } // namespace seastar_ffi

--- a/seastar/src/gate.cc
+++ b/seastar/src/gate.cc
@@ -11,5 +11,9 @@ std::unique_ptr<gate_holder> new_gate_holder(const std::unique_ptr<gate>& gate) 
     return std::make_unique<gate_holder>(*gate);
 }
 
+VoidFuture close_gate(const std::unique_ptr<gate>& gate) {
+    co_await gate->close();
+}
+
 } // namespace gate
 } // namespace seastar_ffi

--- a/seastar/src/gate.hh
+++ b/seastar/src/gate.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <seastar/core/gate.hh>
+
+namespace seastar_ffi {
+namespace gate {
+
+} // namespace gate
+} // namespace seastar_ffi

--- a/seastar/src/gate.hh
+++ b/seastar/src/gate.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "cxx_async_futures.hh"
 #include <seastar/core/gate.hh>
 
 namespace seastar_ffi {
@@ -11,6 +12,8 @@ using gate_holder = gate::holder;
 std::unique_ptr<gate> new_gate();
 
 std::unique_ptr<gate_holder> new_gate_holder(const std::unique_ptr<gate>& gate);
+
+VoidFuture close_gate(const std::unique_ptr<gate>& gate);
 
 } // namespace gate
 } // namespace seastar_ffi

--- a/seastar/src/gate.hh
+++ b/seastar/src/gate.hh
@@ -6,8 +6,11 @@ namespace seastar_ffi {
 namespace gate {
 
 using gate = seastar::gate;
+using gate_holder = gate::holder;
 
 std::unique_ptr<gate> new_gate();
+
+std::unique_ptr<gate_holder> new_gate_holder(const std::unique_ptr<gate>& gate);
 
 } // namespace gate
 } // namespace seastar_ffi

--- a/seastar/src/gate.hh
+++ b/seastar/src/gate.hh
@@ -5,5 +5,9 @@
 namespace seastar_ffi {
 namespace gate {
 
+using gate = seastar::gate;
+
+std::unique_ptr<gate> new_gate();
+
 } // namespace gate
 } // namespace seastar_ffi

--- a/seastar/src/gate.rs
+++ b/seastar/src/gate.rs
@@ -1,0 +1,8 @@
+#[cxx::bridge(namespace = "seastar_ffi::gate")]
+mod ffi {
+    unsafe extern "C++" {
+        include!("seastar/src/gate.hh");
+    }
+}
+
+use ffi::*;

--- a/seastar/src/gate.rs
+++ b/seastar/src/gate.rs
@@ -1,8 +1,36 @@
+use cxx::UniquePtr;
+
 #[cxx::bridge(namespace = "seastar_ffi::gate")]
 mod ffi {
     unsafe extern "C++" {
         include!("seastar/src/gate.hh");
+
+        type gate;
+
+        fn new_gate() -> UniquePtr<gate>;
     }
 }
 
 use ffi::*;
+
+/// Facility to stop new requests, and to tell when existing requests are done.
+///
+/// When stopping a service that serves asynchronous requests, we are faced with
+/// two problems: preventing new requests from coming in, and knowing when existing
+/// requests have completed. The `Gate` class provides a solution.
+pub struct Gate {
+    inner: UniquePtr<gate>,
+}
+
+impl Default for Gate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Gate {
+    /// Creates a new gate.
+    pub fn new() -> Self {
+        Gate { inner: new_gate() }
+    }
+}

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -7,6 +7,7 @@ mod config_and_start_seastar;
 mod cxx_async_futures;
 mod cxx_async_local_future;
 mod ffi_utils;
+mod gate;
 mod preempt;
 #[cfg(test)]
 pub(crate) mod seastar_test_guard;
@@ -18,6 +19,7 @@ pub(crate) use seastar_test_guard::acquire_guard_for_seastar_test;
 
 pub use api_safety::*;
 pub use config_and_start_seastar::*;
+pub use gate::*;
 pub use preempt::*;
 pub use spawn::*;
 pub use submit_to::*;

--- a/seastar/src/submit_to.rs
+++ b/seastar/src/submit_to.rs
@@ -1,4 +1,3 @@
-use crate as seastar;
 use crate::ffi_utils::{get_dropper, get_fn_once_caller};
 use ffi::*;
 use std::future::Future;
@@ -66,6 +65,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate as seastar;
 
     #[seastar::test]
     async fn test_submit_to() {


### PR DESCRIPTION
Fixes: #4
Depends on: #1, #2, #13

This PR introduces exposition of `seastar::gate` to Rust as `struct Gate` with methods:
```rust
pub fn new() -> Pin<Box<Self>>;
pub fn try_enter(&'a self) -> Result<GateHolder<'a>, GateClosedError>;
pub async fn close(&self);
```
There are also 2 auxiliary types:
- `GateHolder<'a>` – equivalent of `seastar::gate::holder`,
- `GateClosedError` – equivalent of `seastar::gate_closed_exception`.

Currently, there are 3 tests testing the following scenarios:
- `close`,
- `try_enter -> leave -> close`,
- `close -> try_enter` (`GateClosedError` is returned).

A very important case `try_enter -> close -> leave` (`close` waits) hasn't been tested yet, because it requires Seastar runtime. This particular case (and maybe some other cases with more enters) will be tested when Seastar runtime is exposed to Rust.

There are some issues with this PR that I have noticed:
- `GateHolder` holds reference to `gate` just to implement the lifetime. It would be really nice if something like this
  ```rust
  pub struct GateHolder<'a> {
      _holder: 'a UniquePtr<gate_holder>,
  }
  ```
  worked, but unfortunately it doesn't. I haven't found a way to implement `GateHolder` without keeping `&'a gate`.
- Our fork of `cxx-async` is not usable yet, because PR hasn't been accepted  there. Instead, I used fork of our fork.
- `cxx-async` throws many warnings.
- `CloseGateFuture` appears in the documentation generated by `cargo doc` and I don't know how to hide it. This
  ```rust
  #[doc(hidden)]
  type CloseGateFuture = crate::CloseGateFuture;
  ```
  doesn't work.
- `GateClosedError` has a hard coded implemantation of the `Debug` trait. It should be possible to print `seastar::gate_closed_exception::what()` somehow. I'll do it if it is necessarry.