### PR TITLE
Add RUSTDOCFLAGS to cargo test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,4 +40,4 @@ jobs:
     - name: Run linter
       run: cargo clippy --verbose --examples --tests
     - name: Test
-      run: RUSTFLAGS="-C link-arg=-fuse-ld=lld" cargo test
+      run: RUSTFLAGS="-C link-arg=-fuse-ld=lld" RUSTDOCFLAGS="-C link-arg=-fuse-ld=lld" cargo test


### PR DESCRIPTION
Changes provided by this PR:
* RUSTDOCFLAGS added to cargo test
* It is needed to correctly compile tests (examples) from the documentation 