### PR TITLE
Spawn tasks

### DIFF
--- a/seastar/Cargo.toml
+++ b/seastar/Cargo.toml
@@ -9,6 +9,7 @@ links = "seastar"
 [dependencies]
 cxx = "1"
 cxx-async = { git = "https://github.com/kfernandez31/cxx-async", branch = "seastar" }
+futures = "0.3.25"
 pin-project = "1"
 seastar-macros = { path = "../seastar-macros" }
 

--- a/seastar/build.rs
+++ b/seastar/build.rs
@@ -5,9 +5,14 @@ static CXX_BRIDGES: &[&str] = &[
     "src/preempt.rs",
     "src/config_and_start_seastar.rs",
     "src/api_safety.rs",
+    "src/spawn.rs",
 ];
 
-static CXX_CPP_SOURCES: &[&str] = &["src/config_and_start_seastar.cc"];
+static CXX_CPP_SOURCES: &[&str] = &[
+    // Put all cpp source files into this list
+    "src/config_and_start_seastar.cc",
+    "src/spawn.cc",
+];
 
 fn main() {
     let seastar = pkg_config::Config::new()

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -3,14 +3,13 @@
 //! Work in progress! Definitely not for use in production yet.
 
 mod api_safety;
+mod config_and_start_seastar;
 mod cxx_async_futures;
 mod cxx_async_local_future;
-
-mod config_and_start_seastar;
 mod preempt;
-
 #[cfg(test)]
 pub(crate) mod seastar_test_guard;
+mod spawn;
 
 #[cfg(test)]
 pub(crate) use seastar_test_guard::acquire_guard_for_seastar_test;
@@ -18,6 +17,7 @@ pub(crate) use seastar_test_guard::acquire_guard_for_seastar_test;
 pub use api_safety::*;
 pub use config_and_start_seastar::*;
 pub use preempt::*;
+pub use spawn::*;
 
 /// A macro intended for running asynchronous tests.
 ///

--- a/seastar/src/spawn.cc
+++ b/seastar/src/spawn.cc
@@ -1,0 +1,24 @@
+#include <seastar/core/task.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/make_task.hh>
+#include <seastar/core/coroutine.hh>
+
+#include "spawn.hh"
+
+namespace seastar_ffi {
+namespace spawn {
+
+VoidFuture cpp_spawn(VoidFuture future) {
+    seastar::promise<> p;
+    auto f = p.get_future();
+    auto t = seastar::make_task([&]() -> seastar::future<> {
+        auto local_p = std::move(p);
+        co_await std::move(future);
+        local_p.set_value(); 
+    });
+    seastar::schedule(t);
+    co_await std::move(f);
+}
+
+}
+}

--- a/seastar/src/spawn.hh
+++ b/seastar/src/spawn.hh
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "cxx-async/include/rust/cxx_async_seastar.h"
+#include "rust/cxx.h"
+#include "cxx_async_futures.hh"
+
+namespace seastar_ffi {
+namespace spawn {
+
+VoidFuture cpp_spawn(VoidFuture future);
+
+} // namespace spawn
+} // namespace seastar_ffi

--- a/seastar/src/spawn.rs
+++ b/seastar/src/spawn.rs
@@ -1,0 +1,48 @@
+use crate as seastar;
+use crate::cxx_async_local_future::IntoCxxAsyncLocalFuture;
+use core::cell::Cell;
+use ffi::*;
+use std::future::Future;
+use std::rc::Rc;
+
+#[cxx::bridge]
+mod ffi {
+    #[namespace = "seastar_ffi"]
+    unsafe extern "C++" {
+        type VoidFuture = crate::cxx_async_futures::VoidFuture;
+    }
+
+    #[namespace = "seastar_ffi::spawn"]
+    unsafe extern "C++" {
+        include!("seastar/src/spawn.hh");
+
+        fn cpp_spawn(future: VoidFuture) -> VoidFuture;
+    }
+}
+
+/// Spawns a new asynchronous task, returning an `Ret`.
+///
+/// The provided future will start running in the background immediately
+/// when `spawn` is called.
+///
+/// Spawning a task enables the task to execute concurrently to other tasks.
+///
+/// This function must be called from the context of a Seastar runtime.
+pub async fn spawn<T, Ret: 'static>(future: T) -> Ret
+where
+    T: Future<Output = Ret> + 'static,
+{
+    seastar::assert_runtime_is_running();
+
+    let x: Rc<Cell<Option<Ret>>> = Default::default();
+
+    let x_clone = x.clone();
+    match cpp_spawn(VoidFuture::infallible_local(async move {
+        x_clone.set(Some(future.await));
+    }))
+    .await
+    {
+        Ok(_) => x.take().unwrap(),
+        Err(_) => panic!(),
+    }
+}

--- a/seastar/src/spawn.rs
+++ b/seastar/src/spawn.rs
@@ -46,3 +46,44 @@ where
         Err(_) => panic!(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[seastar::test]
+    async fn test_empty_spawn_void() {
+        assert!(matches!(spawn(async move {}).await, ()));
+    }
+
+    #[seastar::test]
+    async fn test_chained_spawn_void() {
+        let res = spawn(async move {
+            let _ = spawn(async move {}).await;
+        })
+        .await;
+        assert!(matches!(res, ()));
+    }
+
+    #[seastar::test]
+    async fn test_spawn_int() {
+        let res = spawn(async move { 0 }).await;
+        assert!(matches!(res, 0));
+    }
+
+    #[seastar::test]
+    async fn test_two_spawn_int_and_void() {
+        let mut res = spawn(async move { 0 }).await;
+        assert!(matches!(res, 0));
+        res = spawn(async move { 1 }).await;
+        assert!(matches!(res, 1));
+        assert!(matches!(spawn(async move {}).await, ()));
+        assert!(matches!(spawn(async move {}).await, ()));
+    }
+
+    #[seastar::test]
+    async fn test_chained_spawn_int() {
+        let res = spawn(async move { spawn(async move { 2 }).await }).await;
+        assert!(matches!(res, 2));
+    }
+}


### PR DESCRIPTION
Fixes: #5 
Depends on: #24, #27 

This PR introduces a way to spawn tasks on the local shard in Rust by method:
```rust
pub async fn spawn<T, Ret: 'static>(future: T) -> Option<Ret>
where
    T: Future<Output = Ret> + 'static
```
For example:
```rust
let _ = spawn(async move {
            spawn(async move {
                return 2;
            })
            .await
            .unwrap()
        })
        .await;
```
