### PR TITLE
Add module for configuring and starting seastar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
+.idea
 /target
 /Cargo.lock

--- a/seastar/Cargo.toml
+++ b/seastar/Cargo.toml
@@ -11,6 +11,9 @@ cxx = "1"
 cxx-async = { git = "https://github.com/kfernandez31/cxx-async", branch = "seastar" }
 pin-project = "1"
 
+[dev-dependencies]
+num_cpus = "1.15.0"
+
 [build-dependencies]
 cxx-build = { version = "1", features = ["parallel"] }
 pkg-config = "0.3"

--- a/seastar/Cargo.toml
+++ b/seastar/Cargo.toml
@@ -8,6 +8,8 @@ links = "seastar"
 
 [dependencies]
 cxx = "1"
+cxx-async = { git = "https://github.com/kfernandez31/cxx-async", branch = "seastar" }
+pin-project = "1"
 
 [build-dependencies]
 cxx-build = { version = "1", features = ["parallel"] }

--- a/seastar/build.rs
+++ b/seastar/build.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 static CXX_BRIDGES: &[&str] = &[
     // Put all files that contain a cxx::bridge into this list
     "src/preempt.rs",
+    "src/config_and_start_seastar.rs",
 ];
+
+static CXX_CPP_SOURCES: &[&str] = &["src/config_and_start_seastar.cc"];
 
 fn main() {
     let seastar = pkg_config::Config::new()
@@ -43,10 +46,14 @@ fn main() {
         .flag_if_supported("-fcoroutines")
         .includes(&seastar.include_paths)
         .cpp_link_stdlib("stdc++")
+        .files(CXX_CPP_SOURCES)
         .compile("seastar-rs");
 
     println!("cargo:rerun-if-changed=build.rs");
     for bridge_file in cxx_bridges.iter() {
         println!("cargo:rerun-if-changed={}", bridge_file.to_str().unwrap());
+    }
+    for cpp_file in CXX_CPP_SOURCES.iter() {
+        println!("cargo:rerun-if-changed={}", cpp_file);
     }
 }

--- a/seastar/src/config_and_start_seastar.cc
+++ b/seastar/src/config_and_start_seastar.cc
@@ -1,0 +1,57 @@
+#include "config_and_start_seastar.hh"
+
+namespace seastar_ffi {
+namespace config_and_start_seastar {
+
+std::unique_ptr<seastar_options> new_options() {
+    return std::make_unique<seastar_options>();
+}
+
+rust::Str get_name(const seastar_options& opts) {
+    return rust::Str(opts.name.begin(), opts.name.size());
+}
+
+rust::Str get_description(const seastar_options& opts) {
+    return rust::Str(opts.description.begin(), opts.description.size());
+}
+
+uint32_t get_smp(const seastar_options& opts) {
+    if (opts.smp_opts.smp) {
+        return (uint32_t)opts.smp_opts.smp.get_value();
+    } else {
+        return (uint32_t)seastar::get_current_cpuset().size();
+    }
+}
+
+void set_name(seastar_options& opts, const rust::Str name) {
+    opts.name = seastar::sstring(name.begin(), name.size());
+}
+
+void set_description(seastar_options& opts, const rust::Str description) {
+    opts.description = seastar::sstring(description.begin(), description.size());
+}
+
+void set_smp(seastar_options& opts, const uint32_t smp) {
+    opts.smp_opts.smp.set_value((unsigned)smp);
+}
+
+std::unique_ptr<app_template> new_app_template_from_options(seastar_options& opts) {
+    return std::make_unique<app_template>(std::move(opts));
+}
+
+int32_t run_void(app_template& app, int32_t argc, char** argv, VoidFuture fut) {
+    int32_t exit_value = app.run((int)argc, argv, [&]() -> seastar::future<> {
+        co_await std::move(fut);
+    });
+    return exit_value;
+}
+
+int32_t run_int(app_template& app, int32_t argc, char** argv, IntFuture fut) {
+    int32_t exit_value = app.run((int)argc, argv, [&]() -> seastar::future<int> {
+        co_return co_await std::move(fut);
+    });
+    return exit_value;
+}
+
+} // namespace config_and_start_seastar
+} // namespace seastar

--- a/seastar/src/config_and_start_seastar.hh
+++ b/seastar/src/config_and_start_seastar.hh
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "cxx_async_futures.hh"
+#include <seastar/core/app-template.hh>
+
+namespace seastar_ffi {
+namespace config_and_start_seastar {
+
+using app_template = seastar::app_template;
+using seastar_options = app_template::seastar_options;
+
+using VoidFuture = seastar_ffi::VoidFuture;
+using IntFuture = seastar_ffi::IntFuture;
+
+std::unique_ptr<seastar_options> new_options();
+
+rust::Str get_name(const seastar_options& opts);
+
+rust::Str get_description(const seastar_options& opts);
+
+uint32_t get_smp(const seastar_options& opts);
+
+void set_name(seastar_options& opts, const rust::Str name);
+
+void set_description(seastar_options& opts, const rust::Str description);
+
+void set_smp(seastar_options& opts, const uint32_t smp);
+
+std::unique_ptr<app_template> new_app_template_from_options(seastar_options& opts);
+
+int32_t run_void(app_template& app, int argc, char** args, VoidFuture fut);
+
+int32_t run_int(app_template& app, int argc, char** args, IntFuture fut);
+
+} // namespace config_and_start_seastar
+} // namespace seastar

--- a/seastar/src/config_and_start_seastar.rs
+++ b/seastar/src/config_and_start_seastar.rs
@@ -361,6 +361,7 @@ mod tests {
     #[test]
     fn test_run_int() {
         thread::spawn(|| {
+            let _guard = crate::acquire_guard_for_seastar_test();
             let mut app = AppTemplate::default();
             let args = vec!["test"];
             let fut = async { Ok(42) };
@@ -373,6 +374,7 @@ mod tests {
     #[test]
     fn test_run_void() {
         thread::spawn(|| {
+            let _guard = crate::acquire_guard_for_seastar_test();
             let mut app = AppTemplate::default();
             let args = vec!["test"];
             let fut = async { Ok(()) };

--- a/seastar/src/config_and_start_seastar.rs
+++ b/seastar/src/config_and_start_seastar.rs
@@ -1,0 +1,398 @@
+use std::{
+    ffi::{c_char, CString, OsString},
+    future::Future,
+};
+
+use cxx::UniquePtr;
+use ffi::*;
+
+use crate::cxx_async_local_future::IntoCxxAsyncLocalFuture;
+
+#[cxx::bridge]
+mod ffi {
+    #[namespace = "seastar_ffi"]
+    unsafe extern "C++" {
+        type VoidFuture = crate::cxx_async_futures::VoidFuture;
+        type IntFuture = crate::cxx_async_futures::IntFuture;
+    }
+
+    #[namespace = "seastar_ffi::config_and_start_seastar"]
+    unsafe extern "C++" {
+        include!("seastar/src/config_and_start_seastar.hh");
+
+        type seastar_options;
+        type app_template;
+
+        // Returns a pointer to default `seastar_options`
+        fn new_options() -> UniquePtr<seastar_options>;
+        // Getters
+        fn get_name(opts: &seastar_options) -> &str;
+        fn get_description(opts: &seastar_options) -> &str;
+        fn get_smp(opts: &seastar_options) -> u32;
+        // Setters
+        fn set_name(opts: Pin<&mut seastar_options>, name: &str);
+        fn set_description(opts: Pin<&mut seastar_options>, description: &str);
+        fn set_smp(opts: Pin<&mut seastar_options>, smp: u32);
+
+        // Returns a pointer to an `app_template` instance
+        fn new_app_template_from_options(
+            opts: Pin<&mut seastar_options>,
+        ) -> UniquePtr<app_template>;
+        // These run the app
+        unsafe fn run_void(
+            app: Pin<&mut app_template>,
+            argc: i32,
+            args: *mut *mut c_char,
+            fut: VoidFuture,
+        ) -> i32;
+        unsafe fn run_int(
+            app: Pin<&mut app_template>,
+            argc: i32,
+            args: *mut *mut c_char,
+            fut: IntFuture,
+        ) -> i32;
+    }
+}
+
+/// The configuration of an [`AppTemplate`] instance.
+/// Some of the options are just metadata, others affect the app's performance.
+pub struct Options {
+    opts: UniquePtr<seastar_options>,
+}
+
+impl Options {
+    /// Creates a default instance of `Options`.
+    ///
+    /// # Seastar's defaults
+    ///
+    /// - `name` - "App",
+    /// - `description` - "" (empty),
+    /// - `smp` - number of threads/cores.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seastar::{AppTemplate, Options};
+    ///
+    /// let opts = Options::new();
+    /// let app = AppTemplate::new_from_options(opts);
+    /// ```
+    pub fn new() -> Self {
+        Options {
+            opts: new_options(),
+        }
+    }
+
+    /// Gets the `Options`' name.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seastar::Options;
+    ///
+    /// let opts = Options::new();
+    ///
+    /// assert_eq!(opts.get_name(), "App");
+    /// ```
+    pub fn get_name(&self) -> &str {
+        get_name(&self.opts)
+    }
+
+    /// Gets the `Options`' description.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seastar::Options;
+    ///
+    /// let opts = Options::new();
+    ///
+    /// assert_eq!(opts.get_description(), "");
+    /// ```
+    pub fn get_description(&self) -> &str {
+        get_description(&self.opts)
+    }
+
+    /// Gets the `Options`' number of threads.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seastar::Options;
+    ///
+    /// let opts = Options::new();
+    ///
+    /// assert_eq!(opts.get_smp(), num_cpus::get() as u32);
+    /// ```
+    pub fn get_smp(&self) -> u32 {
+        get_smp(&self.opts)
+    }
+
+    /// Sets the `Options`' name.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seastar::Options;
+    ///
+    /// let mut opts = Options::new();
+    /// let name = "My Awesome Seastar App";
+    /// opts.set_name(name);
+    ///
+    /// assert_eq!(opts.get_name(), name);
+    /// ```
+    pub fn set_name(&mut self, name: &str) {
+        set_name(self.opts.pin_mut(), name);
+    }
+
+    /// Sets the `Options`' description.
+    ///
+    /// # Examples
+    ///
+    ///```rust
+    /// use seastar::Options;
+    ///
+    /// let mut opts = Options::new();
+    /// let description = "I love Seastar";
+    /// opts.set_description(description);
+    ///
+    /// assert_eq!(opts.get_description(), description);
+    /// ```
+    pub fn set_description(&mut self, description: &str) {
+        set_description(self.opts.pin_mut(), description);
+    }
+
+    /// Sets the `Options`' number of threads.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seastar::Options;
+    ///
+    /// let mut opts = Options::new();
+    /// let smp = 42;
+    /// opts.set_smp(smp);
+    ///
+    /// assert_eq!(opts.get_smp(), smp);
+    /// ```
+    pub fn set_smp(&mut self, smp: u32) {
+        set_smp(self.opts.pin_mut(), smp);
+    }
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Options::new()
+    }
+}
+
+/// The object through which the contents of a `main` function would be ran in a Seastar app.
+/// Configurable through [`Options`].
+pub struct AppTemplate {
+    app: UniquePtr<app_template>,
+}
+
+impl AppTemplate {
+    /// Creates a Seastar app based on its configuration (`[seastar-rs::AppTemplate`]).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seastar::{AppTemplate, Options};
+    ///
+    /// let app = AppTemplate::new_from_options(Options::default());
+    /// ```
+    pub fn new_from_options(mut opts: Options) -> Self {
+        AppTemplate {
+            app: new_app_template_from_options(opts.opts.pin_mut()),
+        }
+    }
+
+    /// Runs an app with a void callback (the output of which is always 0) and program arguments (argv).
+    ///
+    /// Currently, this function can only be called once in a single thread.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seastar::AppTemplate;
+    ///
+    /// let fut = async move { Ok(()) };
+    ///
+    /// let mut app = AppTemplate::default();
+    /// let args = vec!["hello"];
+    ///
+    /// assert_eq!(app.run_void(&args[..], fut), 0);
+    /// ```
+    pub fn run_void<I, Arg>(
+        &mut self,
+        args: I,
+        fut: impl Future<Output = cxx_async::CxxAsyncResult<()>> + 'static,
+    ) -> i32
+    where
+        I: IntoIterator<Item = Arg>,
+        Arg: Into<OsString>,
+    {
+        let args = get_c_args(args);
+        let argc = args.len() as i32;
+        let mut args: Vec<_> = args.iter().map(|s| s.as_ptr() as *mut c_char).collect();
+        args.push(std::ptr::null_mut());
+        unsafe {
+            run_void(
+                self.app.pin_mut(),
+                argc,
+                args.as_mut_ptr(),
+                VoidFuture::fallible_local(fut),
+            )
+        }
+    }
+
+    /// Runs an app with an int (status code) callback and program arguments (argv).
+    ///
+    /// Currently, this function can only be called once in a single thread.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seastar::AppTemplate;
+    ///
+    /// let fut = async move { Ok(42) };
+    ///
+    /// let mut app = AppTemplate::default();
+    /// let args = vec!["hello"];
+    ///
+    /// assert_eq!(app.run_int(&args[..], fut), 42);
+    /// ```
+    pub fn run_int<I, Arg>(
+        &mut self,
+        args: I,
+        fut: impl Future<Output = cxx_async::CxxAsyncResult<i32>> + 'static,
+    ) -> i32
+    where
+        I: IntoIterator<Item = Arg>,
+        Arg: Into<OsString>,
+    {
+        let args = get_c_args(args);
+        let argc = args.len() as i32;
+        let mut args: Vec<_> = args.iter().map(|s| s.as_ptr() as *mut c_char).collect();
+        args.push(std::ptr::null_mut());
+        unsafe {
+            run_int(
+                self.app.pin_mut(),
+                argc,
+                args.as_mut_ptr(),
+                IntFuture::fallible_local(fut),
+            )
+        }
+    }
+}
+
+impl Default for AppTemplate {
+    fn default() -> Self {
+        AppTemplate::new_from_options(Options::default())
+    }
+}
+
+fn get_c_args<I, Arg>(iter: I) -> Vec<CString>
+where
+    I: IntoIterator<Item = Arg>,
+    Arg: Into<OsString>,
+{
+    use std::os::unix::ffi::OsStringExt;
+    iter.into_iter()
+        .map(|os| {
+            let v = os.into().into_vec();
+            CString::new(v).unwrap_or_else(|err| {
+                let nul_position = err.nul_position();
+                let mut v = err.into_vec();
+                v.truncate(nul_position);
+                CString::new(v).unwrap()
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn test_new_options_contain_default_values() {
+        let opts = Options::new();
+        assert_eq!(opts.get_name(), "App");
+        assert_eq!(opts.get_description(), "");
+        assert_eq!(opts.get_smp(), num_cpus::get() as u32);
+    }
+
+    #[test]
+    fn test_set_get_name() {
+        let mut opts = Options::new();
+        let name = "42";
+        opts.set_name(name);
+        assert_eq!(opts.get_name(), name);
+    }
+
+    #[test]
+    fn test_set_get_description() {
+        let mut opts = Options::new();
+        let description = "42";
+        opts.set_description(description);
+        assert_eq!(opts.get_description(), description);
+    }
+
+    #[test]
+    fn test_set_get_smp() {
+        let mut opts = Options::new();
+        let smp = 42;
+        opts.set_smp(smp);
+        assert_eq!(opts.get_smp(), smp);
+    }
+
+    #[test]
+    fn test_new_app_template_from_options_gets_created() {
+        let mut opts = Options::default();
+        opts.set_name("42");
+        opts.set_description("42");
+        opts.set_smp(42);
+        let _ = AppTemplate::new_from_options(opts);
+    }
+
+    #[test]
+    fn test_run_int() {
+        thread::spawn(|| {
+            let mut app = AppTemplate::default();
+            let args = vec!["test"];
+            let fut = async { Ok(42) };
+            assert_eq!(app.run_int(&args[..], fut), 42);
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
+    fn test_run_void() {
+        thread::spawn(|| {
+            let mut app = AppTemplate::default();
+            let args = vec!["test"];
+            let fut = async { Ok(()) };
+            assert_eq!(app.run_void(&args[..], fut), 0);
+        })
+        .join()
+        .unwrap();
+    }
+
+    // Note: this is not a test case that is supposed to be run. It is only
+    // supposed to verify that run_void and run_int work with std::env::args().
+    // and std::env::args_os().
+    // We don't actually want to pass the arguments that were passed to the
+    // Rust test runner application.
+    #[allow(unused)]
+    fn test_run_int_void_works_with_std_env_args() {
+        let mut app = AppTemplate::default();
+        app.run_void(std::env::args(), async { Ok(()) });
+        app.run_int(std::env::args(), async { Ok(42) });
+        app.run_void(std::env::args_os(), async { Ok(()) });
+        app.run_int(std::env::args_os(), async { Ok(42) });
+    }
+}

--- a/seastar/src/cxx_async_futures.hh
+++ b/seastar/src/cxx_async_futures.hh
@@ -1,0 +1,7 @@
+#include "rust/cxx.h"
+#include "cxx-async/include/rust/cxx_async.h"
+#include "cxx-async/include/rust/cxx_async_seastar.h"
+#include <seastar/core/coroutine.hh>
+
+CXXASYNC_DEFINE_FUTURE(void, seastar_ffi, VoidFuture);
+CXXASYNC_DEFINE_FUTURE(int, seastar_ffi, IntFuture);

--- a/seastar/src/cxx_async_futures.rs
+++ b/seastar/src/cxx_async_futures.rs
@@ -1,0 +1,11 @@
+use std::future::Future;
+
+#[cxx_async::bridge(namespace = seastar_ffi)]
+unsafe impl Future for VoidFuture {
+    type Output = ();
+}
+
+#[cxx_async::bridge(namespace = seastar_ffi)]
+unsafe impl Future for IntFuture {
+    type Output = i32;
+}

--- a/seastar/src/cxx_async_local_future.rs
+++ b/seastar/src/cxx_async_local_future.rs
@@ -1,0 +1,40 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use cxx_async::{CxxAsyncResult, IntoCxxAsyncFuture};
+use pin_project::pin_project;
+
+#[pin_project]
+struct LocalFuture<F>(#[pin] F);
+
+impl<F> Future for LocalFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().0.poll(cx)
+    }
+}
+
+unsafe impl<F> Send for LocalFuture<F> {}
+
+pub(crate) trait IntoCxxAsyncLocalFuture: IntoCxxAsyncFuture {
+    fn infallible_local<Fut>(future: Fut) -> Self
+    where
+        Fut: Future<Output = Self::Output> + 'static,
+    {
+        Self::infallible(LocalFuture(future))
+    }
+
+    fn fallible_local<Fut>(future: Fut) -> Self
+    where
+        Fut: Future<Output = CxxAsyncResult<Self::Output>> + 'static,
+    {
+        Self::fallible(LocalFuture(future))
+    }
+}
+
+impl<F> IntoCxxAsyncLocalFuture for F where F: IntoCxxAsyncFuture {}

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -2,8 +2,11 @@
 //!
 //! Work in progress! Definitely not for use in production yet.
 
+mod cxx_async_futures;
 mod cxx_async_local_future;
 
+mod config_and_start_seastar;
 mod preempt;
 
+pub use config_and_start_seastar::*;
 pub use preempt::*;

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Work in progress! Definitely not for use in production yet.
 
+mod cxx_async_local_future;
+
 mod preempt;
 
 pub use preempt::*;

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -8,5 +8,11 @@ mod cxx_async_local_future;
 mod config_and_start_seastar;
 mod preempt;
 
+#[cfg(test)]
+pub(crate) mod seastar_test_guard;
+
+#[cfg(test)]
+pub(crate) use seastar_test_guard::acquire_guard_for_seastar_test;
+
 pub use config_and_start_seastar::*;
 pub use preempt::*;

--- a/seastar/src/seastar_test_guard.rs
+++ b/seastar/src/seastar_test_guard.rs
@@ -1,0 +1,25 @@
+use std::sync::{Mutex, MutexGuard};
+
+static RUNNING_TEST_WITH_SEASTAR: Mutex<()> = Mutex::new(());
+
+pub(crate) struct RunningTestWithSeastarGuard(MutexGuard<'static, ()>);
+
+/// Acquires a global mutex for the purpose of running a test with the
+/// seastar runtime.
+///
+/// Although seastar seems to support starting and stopping the runtime
+/// multiple times in a sequence, it doesn't like (and doesn't detect)
+/// when multiple runtimes are trying to run in parallel. `cargo test` runs
+/// tests in parallel by default, so it's easy to write tests which will
+/// make seastar angry (the anger manifests itself in form of segfaults).
+///
+/// The mutex should be taken by all tests that create a seastar runtime
+/// and held until the test finishes.
+pub(crate) fn acquire_guard_for_seastar_test() -> RunningTestWithSeastarGuard {
+    // If a test panics, we assume that the runtime has been stopped
+    // properly in that test, so we can ignore that the lock is poisoned.
+    let guard = RUNNING_TEST_WITH_SEASTAR
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    RunningTestWithSeastarGuard(guard)
+}


### PR DESCRIPTION
This PR introduces the configure_and_start_seastar module. As the name suggests, it provides functionality necessary to configure and start the seastar runtime.

It contains definitions of the following types:

- `Options` - wrapper over `seastar::app_template::options`. Provides configuration for the seastar runtime.
- `AppTemplate` - wrapper over `seastar::app_template`. Used to start the seastar runtime.

Example:
```rust
let mut app = AppTemplate::default();
let args = vec!["test"];
let fut = async { Ok(42) };
assert_eq!(app.run_int(&args[..], fut), 42);
```

Heavily based on work done in: https://github.com/zpp-2022-rust-seastar/seastar-rs/pull/10 by @kfernandez31, with the help from @sylwiaszunejko and @patjed41.