### PR TITLE
Test macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
     "seastar",
+    "seastar-macros",
 ]

--- a/seastar-macros/Cargo.toml
+++ b/seastar-macros/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "seastar-macros"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/seastar-macros/src/lib.rs
+++ b/seastar-macros/src/lib.rs
@@ -1,0 +1,44 @@
+#[proc_macro_attribute]
+pub fn test(
+    args: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let args = syn::parse_macro_input!(args as proc_macro2::TokenStream);
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let attrs = &input.attrs;
+
+    if input.sig.asyncness.is_none() {
+        let msg = "the async keyword is missing from the function declaration";
+        return syn::Error::new_spanned(input.sig, msg)
+            .to_compile_error()
+            .into();
+    }
+
+    if !args.is_empty() {
+        let msg = "arguments for #[seastar::test] are not supported yet";
+        return syn::Error::new_spanned(args, msg).to_compile_error().into();
+    }
+
+    let output = quote::quote! {
+        #[test]
+        #(#attrs)*
+        fn #name() {
+            std::thread::spawn(|| {
+                let _guard = seastar::acquire_guard_for_seastar_test();
+                let mut app = seastar::AppTemplate::default();
+                let fut = async {
+                    #body
+                    Ok(())
+                };
+                app.run_void(std::env::args().take(1), fut);
+            })
+            .join()
+            .unwrap();
+        }
+    };
+
+    output.into()
+}

--- a/seastar/Cargo.toml
+++ b/seastar/Cargo.toml
@@ -10,6 +10,7 @@ links = "seastar"
 cxx = "1"
 cxx-async = { git = "https://github.com/kfernandez31/cxx-async", branch = "seastar" }
 pin-project = "1"
+seastar-macros = { path = "../seastar-macros" }
 
 [dev-dependencies]
 num_cpus = "1.15.0"

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -16,3 +16,19 @@ pub(crate) use seastar_test_guard::acquire_guard_for_seastar_test;
 
 pub use config_and_start_seastar::*;
 pub use preempt::*;
+
+/// A macro intended for running asynchronous tests.
+///
+/// Tests are spawned in a separate thread.
+/// This is done to ensure thread_local cleanup between them
+/// (at the time of writing, Seastar doesn't do it itself).
+///
+/// # Usage
+///
+/// ```rust
+/// #[seastar::test]
+/// async fn my_test() {
+///     assert!(true);
+/// }
+/// ```
+pub use seastar_macros::test;


### PR DESCRIPTION
Fixes: #2
Depends on #1

This PR introduces a procedural macro like `tokio::test` which allows writing tests in Rust that run on Seastar runtime. For example:
```rust
#[seastar::test]
async fn test_frobnication() {
    // You can use seastar functions here without any problems, and await on them
    do_frobnicate().await;
}
```
With the help from @kfernandez31