### PR TITLE
#[seastar::main] macro

### DIFF
--- a/seastar-macros/src/lib.rs
+++ b/seastar-macros/src/lib.rs
@@ -42,3 +42,70 @@ pub fn test(
 
     output.into()
 }
+
+#[proc_macro_attribute]
+#[cfg(not(test))] // Work around for rust-lang/rust#62127
+pub fn main(
+    args: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let args = syn::parse_macro_input!(args as proc_macro2::TokenStream);
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let output = &input.sig.output;
+    let inputs = &input.sig.inputs;
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let attrs = &input.attrs;
+
+    if input.sig.asyncness.is_none() {
+        let msg = "the async keyword is missing from the function declaration";
+        return syn::Error::new_spanned(input.sig, msg)
+            .to_compile_error()
+            .into();
+    }
+
+    if name != "main" {
+        let msg = "only the main function is allowed to use #[seastar::main]";
+        return syn::Error::new_spanned(input.sig.ident, msg)
+            .to_compile_error()
+            .into();
+    }
+
+    if !inputs.is_empty() {
+        let msg = "the main function cannot accept arguments";
+        return syn::Error::new_spanned(input.sig, msg)
+            .to_compile_error()
+            .into();
+    }
+
+    if !args.is_empty() {
+        let msg = "arguments for #[seastar::test] are not supported yet";
+        return syn::Error::new_spanned(args, msg).to_compile_error().into();
+    }
+
+    let ret_type = match output {
+        syn::ReturnType::Type(_, ty) => ty.clone(),
+        syn::ReturnType::Default => syn::parse_quote! { () },
+    };
+
+    let output = quote::quote! {
+        #(#attrs)*
+        fn main() #output {
+            let ret_holder : std::rc::Rc<std::cell::Cell<Option<#ret_type>>> = Default::default();
+
+            let ret_holder_clone = ret_holder.clone();
+            let fut = async move {
+                let ret = #body;
+                ret_holder_clone.set(Some(ret));
+                Ok(())
+            };
+
+            let mut app = seastar::AppTemplate::default();
+            app.run_void(std::env::args(), fut);
+            ret_holder.take().unwrap()
+        }
+    };
+
+    output.into()
+}

--- a/seastar/examples/main_macro.rs
+++ b/seastar/examples/main_macro.rs
@@ -1,0 +1,8 @@
+async fn frobnicate() -> i32 {
+    42
+}
+
+#[seastar::main]
+async fn main() {
+    println!("Frobnication result: {}", frobnicate().await);
+}

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -34,3 +34,25 @@ pub use preempt::*;
 /// }
 /// ```
 pub use seastar_macros::test;
+
+/// A macro that runs the `main` function's contents
+/// in Seastar's runtime.
+///
+/// **Only** `main` is allowed to use this macro -
+/// Seastar apps may only use one `AppTemplate`
+/// instance at a time.
+///
+/// # Options
+///
+/// Currently, passing options is not supported.
+/// The app is simply run with default parameters.
+///
+/// # Usage
+///
+/// ```rust
+/// #[seastar::main]
+/// async fn main() {
+///     println!("Hello, world!");
+/// }
+/// ```
+pub use seastar_macros::main;


### PR DESCRIPTION
An improvement over #25 (still learning how to do proper PRs).
Fixes: #16
Depends: #23

This PR introduces the `#[seastar::main]` macro. It works exactly as described in #16 .
A minimal example of usage:
```rs
#[seastar::main]
async fn main() {
    hello_world().await;
}
```
What the macro does under the hood is that it calls `run_void` on an `AppTemplate` instance with default `Options`. We may offer some room for configuration in the future, and make the macro accept options as args, but for now, this is enough.