### PR TITLE
Ensuring api safety

### DIFF
--- a/seastar/build.rs
+++ b/seastar/build.rs
@@ -4,6 +4,7 @@ static CXX_BRIDGES: &[&str] = &[
     // Put all files that contain a cxx::bridge into this list
     "src/preempt.rs",
     "src/config_and_start_seastar.rs",
+    "src/api_safety.rs",
 ];
 
 static CXX_CPP_SOURCES: &[&str] = &["src/config_and_start_seastar.cc"];

--- a/seastar/src/api_safety.rs
+++ b/seastar/src/api_safety.rs
@@ -1,0 +1,62 @@
+#[cxx::bridge(namespace = "seastar")]
+mod ffi {
+    unsafe extern "C++" {
+        include!("seastar/core/reactor.hh");
+
+        /// Checks whether the current thread is within a Seastar runtime.
+        fn engine_is_ready() -> bool;
+    }
+}
+
+pub use ffi::engine_is_ready;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AppTemplate;
+    use std::thread;
+
+    #[test]
+    fn test_engine_is_ready_only_for_thread_in_runtime() {
+        assert!(!engine_is_ready());
+
+        thread::spawn(|| {
+            assert!(!engine_is_ready());
+            let _guard = crate::acquire_guard_for_seastar_test();
+            let mut app = AppTemplate::default();
+            let fut = async {
+                assert!(engine_is_ready());
+                Ok(())
+            };
+            let args = vec!["test"];
+            app.run_void(&args, fut);
+            // Currently, Seastar does not perform a cleanup of its thread locals,
+            // which unfortunately means the following assertion will pass.
+            // Should it fail, we must:
+            // 1) negate its condition
+            // 2) review other code in the project that also follows
+            //    this assumption and modify it accordingly.
+            assert!(engine_is_ready());
+        })
+        .join()
+        .unwrap();
+
+        assert!(!engine_is_ready());
+    }
+}
+
+/// Intended to be used in a runtime-dependent function.
+/// Panics if called outside of a Seastar runtime.
+pub fn assert_runtime_is_running() {
+    if !engine_is_ready() {
+        panic!("Attempting to call a runtime-dependent function outside of a Seastar runtime");
+    }
+}
+
+/// Mainly intended to be used in [`seastar::AppTemplate::run_void`] and  [`seastar::AppTemplate::run_int`].
+/// Panics if called within a Seastar runtime.
+pub fn assert_runtime_is_not_running() {
+    if engine_is_ready() {
+        panic!("Attempting to call a function inside of a Seastar runtime that must be used outside of it");
+    }
+}

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Work in progress! Definitely not for use in production yet.
 
+mod api_safety;
 mod cxx_async_futures;
 mod cxx_async_local_future;
 
@@ -14,6 +15,7 @@ pub(crate) mod seastar_test_guard;
 #[cfg(test)]
 pub(crate) use seastar_test_guard::acquire_guard_for_seastar_test;
 
+pub use api_safety::*;
 pub use config_and_start_seastar::*;
 pub use preempt::*;
 


### PR DESCRIPTION
Solves: #13 
Depends: #23

This PR introduces the `seastar::engine_is_ready` method for checking whether the current thread is in a Seastar runtime and the `seastar::assert_runtime_is_running!` and `seastar::assert_runtime_is_not_running!` macros that wrap over it.

We will want to utilize the macros in our APIs to ensure proper app behavior.
Example usage:

```diff
--- a/seastar/src/config_and_start_seastar.rs
+++ b/seastar/src/config_and_start_seastar.rs
@@ -217,6 +217,8 @@ impl AppTemplate {
     {
         let args: Vec<Arg> = args.into_iter().collect();
         let args: Vec<&str> = args.iter().map(|arg| arg.as_ref()).collect();
+        use crate as seastar;
+        assert_runtime_is_not_running!();
         run_void(self.app.pin_mut(), &args, VoidFuture::fallible_local(fut))
     }
```
```diff
--- a/seastar/src/submit_to.rs
+++ b/seastar/src/submit_to.rs
@@ -30,6 +30,8 @@ where
     Fut: Future<Output = Ret> + 'static,
     Ret: Send + 'static,
 {
+    use crate as seastar;
+    assert_runtime_is_running!();
     let (tx, rx) = futures::channel::oneshot::channel::<Ret>();
 
     let closure = move || {
```

[Are the macros hacky?](https://i.kym-cdn.com/photos/images/newsfeed/001/650/747/aaf.png). Well, for now there's no macro in Rust that returns the name of the current function, so some workarounds had to be done. A [PR](https://github.com/rust-lang/rfcs/pull/1719) and some [duplicates](https://github.com/rust-lang/rfcs/pull/2818) of it were open but none came to fruition.