### PR TITLE
Expose the scheduling API to Rust

### DIFF
--- a/seastar/build.rs
+++ b/seastar/build.rs
@@ -12,6 +12,7 @@ static CXX_BRIDGES: &[&str] = &[
     "src/smp.rs",
     "src/distributed.rs",
     "src/file.rs",
+    "src/scheduling.rs",
 ];
 
 static CXX_CPP_SOURCES: &[&str] = &[
@@ -26,6 +27,7 @@ static CXX_CPP_SOURCES: &[&str] = &[
     "src/smp.cc",
     "src/distributed.cc",
     "src/file.cc",
+    "src/scheduling.cc",
 ];
 
 fn main() {

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -12,6 +12,7 @@ mod ffi_utils;
 mod file;
 mod gate;
 mod preempt;
+mod scheduling;
 #[doc(hidden)]
 pub mod seastar_test_guard;
 mod sleep;
@@ -30,6 +31,7 @@ pub use distributed::*;
 pub use file::*;
 pub use gate::*;
 pub use preempt::*;
+pub use scheduling::*;
 pub use sleep::*;
 pub use smp::*;
 pub use spawn::*;

--- a/seastar/src/scheduling.cc
+++ b/seastar/src/scheduling.cc
@@ -28,5 +28,20 @@ bool sg_equal(const scheduling_group& sg1, const scheduling_group& sg2) {
     return sg1 == sg2;
 }
 
+VoidFuture create_sg(std::shared_ptr<scheduling_group>& sg, rust::str name, float shares) {
+    seastar::sstring s_name(name.begin(), name.size());
+    scheduling_group new_sg = co_await seastar::create_scheduling_group(s_name, shares);
+    sg = std::make_shared<scheduling_group>(std::move(new_sg));
+}
+
+VoidFuture destroy_sg(const std::shared_ptr<scheduling_group>& sg) {
+    co_await seastar::destroy_scheduling_group(*sg);
+}
+
+VoidFuture rename_sg(const std::shared_ptr<scheduling_group>& sg, rust::str new_name) {
+    seastar::sstring s_name(new_name.begin(), new_name.size());
+    co_await seastar::rename_scheduling_group(*sg, s_name);
+}
+
 } // namespace scheduling
 } // namespace seastar_ffi

--- a/seastar/src/scheduling.cc
+++ b/seastar/src/scheduling.cc
@@ -3,5 +3,9 @@
 namespace seastar_ffi {
 namespace scheduling {
 
+std::shared_ptr<scheduling_group> new_sg() {
+    return std::make_unique<scheduling_group>();
+}
+
 } // namespace scheduling
 } // namespace seastar_ffi

--- a/seastar/src/scheduling.cc
+++ b/seastar/src/scheduling.cc
@@ -1,0 +1,7 @@
+#include "scheduling.hh"
+
+namespace seastar_ffi {
+namespace scheduling {
+
+} // namespace scheduling
+} // namespace seastar_ffi

--- a/seastar/src/scheduling.cc
+++ b/seastar/src/scheduling.cc
@@ -7,5 +7,22 @@ std::shared_ptr<scheduling_group> new_sg() {
     return std::make_unique<scheduling_group>();
 }
 
+bool sg_active(const scheduling_group& sg) {
+    return sg.active();
+}
+
+rust::str sg_name(const scheduling_group& sg) {
+    const seastar::sstring& sg_name = sg.name();
+    return rust::Str(sg_name.begin(), sg_name.size());
+}
+
+bool sg_is_main(const scheduling_group& sg) {
+    return sg.is_main();
+}
+
+void sg_set_shares(const std::shared_ptr<scheduling_group>& sg, float shares) {
+    sg->set_shares(shares);
+}
+
 } // namespace scheduling
 } // namespace seastar_ffi

--- a/seastar/src/scheduling.cc
+++ b/seastar/src/scheduling.cc
@@ -24,5 +24,9 @@ void sg_set_shares(const std::shared_ptr<scheduling_group>& sg, float shares) {
     sg->set_shares(shares);
 }
 
+bool sg_equal(const scheduling_group& sg1, const scheduling_group& sg2) {
+    return sg1 == sg2;
+}
+
 } // namespace scheduling
 } // namespace seastar_ffi

--- a/seastar/src/scheduling.cc
+++ b/seastar/src/scheduling.cc
@@ -43,5 +43,14 @@ VoidFuture rename_sg(const std::shared_ptr<scheduling_group>& sg, rust::str new_
     co_await seastar::rename_scheduling_group(*sg, s_name);
 }
 
+uint32_t max_sg() {
+    return (uint32_t) seastar::max_scheduling_groups();
+}
+
+std::shared_ptr<scheduling_group> current_sg() {
+    scheduling_group sg = seastar::current_scheduling_group();
+    return std::make_shared<scheduling_group>(std::move(sg));
+}
+
 } // namespace scheduling
 } // namespace seastar_ffi

--- a/seastar/src/scheduling.hh
+++ b/seastar/src/scheduling.hh
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "cxx_async_futures.hh"
+#include <seastar/core/scheduling.hh>
+
+namespace seastar_ffi {
+namespace scheduling {
+
+} // namespace scheduling
+} // namespace seastar_ffi

--- a/seastar/src/scheduling.hh
+++ b/seastar/src/scheduling.hh
@@ -26,5 +26,9 @@ VoidFuture destroy_sg(const std::shared_ptr<scheduling_group>& sg);
 
 VoidFuture rename_sg(const std::shared_ptr<scheduling_group>& sg, rust::str new_name);
 
+uint32_t max_sg();
+
+std::shared_ptr<scheduling_group> current_sg();
+
 } // namespace scheduling
 } // namespace seastar_ffi

--- a/seastar/src/scheduling.hh
+++ b/seastar/src/scheduling.hh
@@ -18,5 +18,7 @@ bool sg_is_main(const scheduling_group& sg);
 
 void sg_set_shares(const std::shared_ptr<scheduling_group>& sg, float shares);
 
+bool sg_equal(const scheduling_group& sg1, const scheduling_group& sg2);
+
 } // namespace scheduling
 } // namespace seastar_ffi

--- a/seastar/src/scheduling.hh
+++ b/seastar/src/scheduling.hh
@@ -20,5 +20,11 @@ void sg_set_shares(const std::shared_ptr<scheduling_group>& sg, float shares);
 
 bool sg_equal(const scheduling_group& sg1, const scheduling_group& sg2);
 
+VoidFuture create_sg(std::shared_ptr<scheduling_group>& sg, rust::str name, float shares);
+
+VoidFuture destroy_sg(const std::shared_ptr<scheduling_group>& sg);
+
+VoidFuture rename_sg(const std::shared_ptr<scheduling_group>& sg, rust::str new_name);
+
 } // namespace scheduling
 } // namespace seastar_ffi

--- a/seastar/src/scheduling.hh
+++ b/seastar/src/scheduling.hh
@@ -10,5 +10,13 @@ using scheduling_group = seastar::scheduling_group;
 
 std::shared_ptr<scheduling_group> new_sg();
 
+bool sg_active(const scheduling_group& sg);
+
+rust::str sg_name(const scheduling_group& sg);
+
+bool sg_is_main(const scheduling_group& sg);
+
+void sg_set_shares(const std::shared_ptr<scheduling_group>& sg, float shares);
+
 } // namespace scheduling
 } // namespace seastar_ffi

--- a/seastar/src/scheduling.hh
+++ b/seastar/src/scheduling.hh
@@ -6,5 +6,9 @@
 namespace seastar_ffi {
 namespace scheduling {
 
+using scheduling_group = seastar::scheduling_group;
+
+std::shared_ptr<scheduling_group> new_sg();
+
 } // namespace scheduling
 } // namespace seastar_ffi

--- a/seastar/src/scheduling.rs
+++ b/seastar/src/scheduling.rs
@@ -28,6 +28,10 @@ mod ffi {
         fn destroy_sg(sg: &SharedPtr<scheduling_group>) -> VoidFuture;
 
         fn rename_sg(sg: &SharedPtr<scheduling_group>, new_name: &str) -> VoidFuture;
+
+        fn max_sg() -> u32;
+
+        fn current_sg() -> SharedPtr<scheduling_group>;
     }
 }
 
@@ -138,5 +142,18 @@ impl SchedulingGroup {
     pub async fn rename(&self, new_name: &str) {
         assert_runtime_is_running();
         rename_sg(&self.inner, new_name).await.unwrap();
+    }
+
+    /// Returns the maximal number of scheduling groups defined by
+    /// `SEASTAR_SCHEDULING_GROUPS_COUNT`.
+    pub fn max() -> u32 {
+        max_sg()
+    }
+
+    /// Returns the current scheduling group.
+    pub fn current() -> Self {
+        SchedulingGroup {
+            inner: current_sg(),
+        }
     }
 }

--- a/seastar/src/scheduling.rs
+++ b/seastar/src/scheduling.rs
@@ -1,8 +1,30 @@
+use cxx::SharedPtr;
+
 #[cxx::bridge(namespace = "seastar_ffi::scheduling")]
 mod ffi {
     unsafe extern "C++" {
         include!("seastar/src/scheduling.hh");
+
+        type scheduling_group;
+
+        fn new_sg() -> SharedPtr<scheduling_group>;
     }
 }
 
 use ffi::*;
+
+/// Identifies function calls that are accounted as a group.
+///
+/// A `SchedulingGroup` is a tag that can be used to mark a function call.
+/// Executions of such tagged calls are accounted as a group.
+#[derive(Clone)]
+pub struct SchedulingGroup {
+    pub(crate) inner: SharedPtr<scheduling_group>,
+}
+
+impl Default for SchedulingGroup {
+    /// Creates a `SchedulingGroup` instance denoting the default group.
+    fn default() -> Self {
+        SchedulingGroup { inner: new_sg() }
+    }
+}

--- a/seastar/src/scheduling.rs
+++ b/seastar/src/scheduling.rs
@@ -17,6 +17,8 @@ mod ffi {
         fn sg_is_main(sg: &scheduling_group) -> bool;
 
         fn sg_set_shares(sg: &SharedPtr<scheduling_group>, shares: f32);
+
+        fn sg_equal(sg1: &scheduling_group, sg2: &scheduling_group) -> bool;
     }
 }
 
@@ -37,6 +39,14 @@ impl Default for SchedulingGroup {
         SchedulingGroup { inner: new_sg() }
     }
 }
+
+impl PartialEq for SchedulingGroup {
+    fn eq(&self, other: &Self) -> bool {
+        sg_equal(&self.inner, &other.inner)
+    }
+}
+
+impl Eq for SchedulingGroup {}
 
 impl SchedulingGroup {
     /// Checks if the group is active.

--- a/seastar/src/scheduling.rs
+++ b/seastar/src/scheduling.rs
@@ -1,0 +1,8 @@
+#[cxx::bridge(namespace = "seastar_ffi::scheduling")]
+mod ffi {
+    unsafe extern "C++" {
+        include!("seastar/src/scheduling.hh");
+    }
+}
+
+use ffi::*;

--- a/seastar/src/scheduling.rs
+++ b/seastar/src/scheduling.rs
@@ -1,3 +1,4 @@
+use crate::assert_runtime_is_running;
 use cxx::SharedPtr;
 
 #[cxx::bridge(namespace = "seastar_ffi::scheduling")]
@@ -8,6 +9,14 @@ mod ffi {
         type scheduling_group;
 
         fn new_sg() -> SharedPtr<scheduling_group>;
+
+        fn sg_active(sg: &scheduling_group) -> bool;
+
+        fn sg_name(sg: &scheduling_group) -> &str;
+
+        fn sg_is_main(sg: &scheduling_group) -> bool;
+
+        fn sg_set_shares(sg: &SharedPtr<scheduling_group>, shares: f32);
     }
 }
 
@@ -26,5 +35,41 @@ impl Default for SchedulingGroup {
     /// Creates a `SchedulingGroup` instance denoting the default group.
     fn default() -> Self {
         SchedulingGroup { inner: new_sg() }
+    }
+}
+
+impl SchedulingGroup {
+    /// Checks if the group is active.
+    pub fn active(&self) -> bool {
+        sg_active(&self.inner)
+    }
+
+    /// Returns the name of the group.
+    pub fn name(&self) -> &str {
+        assert_runtime_is_running();
+        sg_name(&self.inner)
+    }
+
+    /// Checks if the group is main (default).
+    pub fn is_main(&self) -> bool {
+        sg_is_main(&self.inner)
+    }
+
+    /// Adjusts the number of shares allotted to the group.
+    ///
+    /// Dynamically adjusts the number of shares allotted to the group, increasing or
+    /// decreasing the amount of CPU bandwidth it gets. The adjustment is local to
+    /// the shard.
+    ///
+    /// This can be used to reduce a background job's interference with a foreground
+    /// load: the shares can be started at a low value, increased when the background
+    /// job's backlog increases, and reduced again when the backlog decreases.
+    ///
+    /// # Arguments
+    /// * `shares` - The number of shares allotted to the group. Use numbers in the
+    ///   1-1000 range.
+    pub fn set_shares(&self, shares: f32) {
+        assert_runtime_is_running();
+        sg_set_shares(&self.inner, shares);
     }
 }

--- a/seastar/src/scheduling.rs
+++ b/seastar/src/scheduling.rs
@@ -35,6 +35,7 @@ mod ffi {
     }
 }
 
+pub(crate) use ffi::scheduling_group;
 use ffi::*;
 
 /// Identifies function calls that are accounted as a group.

--- a/seastar/src/timer.cc
+++ b/seastar/src/timer.cc
@@ -75,6 +75,16 @@ void sct_set_callback(
     timer.set_callback(callback_object(callback, caller, dropper));
 }
 
+void sct_set_callback_under_group(
+    steady_clock_timer& timer,
+    uint8_t* callback,
+    rust::Fn<void(uint8_t*)> caller,
+    rust::Fn<void(uint8_t*)> dropper,
+    const scheduling_group& sg
+) {
+    timer.set_callback(sg, callback_object(callback, caller, dropper));
+}
+
 void sct_arm_at(steady_clock_timer& timer, int64_t at) {
     timer.arm(to_sc_time_point(at));
 }
@@ -124,6 +134,16 @@ void lct_set_callback(
     timer.set_callback(callback_object(callback, caller, dropper));
 }
 
+void lct_set_callback_under_group(
+    lowres_clock_timer& timer,
+    uint8_t* callback,
+    rust::Fn<void(uint8_t*)> caller,
+    rust::Fn<void(uint8_t*)> dropper,
+    const scheduling_group& sg
+) {
+    timer.set_callback(sg, callback_object(callback, caller, dropper));
+}
+
 void lct_arm_at(lowres_clock_timer& timer, int64_t at) {
     timer.arm(to_lc_time_point(at));
 }
@@ -171,6 +191,16 @@ void mct_set_callback(
     rust::Fn<void(uint8_t*)> dropper
 ) {
     timer.set_callback(callback_object(callback, caller, dropper));
+}
+
+void mct_set_callback_under_group(
+    manual_clock_timer& timer,
+    uint8_t* callback,
+    rust::Fn<void(uint8_t*)> caller,
+    rust::Fn<void(uint8_t*)> dropper,
+    const scheduling_group& sg
+) {
+    timer.set_callback(sg, callback_object(callback, caller, dropper));
 }
 
 void mct_arm_at(manual_clock_timer& timer, int64_t at) {

--- a/seastar/src/timer.hh
+++ b/seastar/src/timer.hh
@@ -7,6 +7,8 @@
 namespace seastar_ffi {
 namespace timer {
 
+using scheduling_group = seastar::scheduling_group;
+
 namespace steady_clock {
 
 using steady_clock_timer = seastar::timer<seastar::steady_clock_type>;
@@ -18,6 +20,14 @@ void sct_set_callback(
     uint8_t* callback, // uint8_t is a substitute for void that isn't supported by cxx.
     rust::Fn<void(uint8_t*)> caller,
     rust::Fn<void(uint8_t*)> dropper
+);
+
+void sct_set_callback_under_group(
+    steady_clock_timer& timer,
+    uint8_t* callback,
+    rust::Fn<void(uint8_t*)> caller,
+    rust::Fn<void(uint8_t*)> dropper,
+    const scheduling_group& sg
 );
 
 void sct_arm_at(steady_clock_timer& timer, int64_t at);
@@ -49,6 +59,14 @@ void lct_set_callback(
     rust::Fn<void(uint8_t*)> dropper
 );
 
+void lct_set_callback_under_group(
+    lowres_clock_timer& timer,
+    uint8_t* callback,
+    rust::Fn<void(uint8_t*)> caller,
+    rust::Fn<void(uint8_t*)> dropper,
+    const scheduling_group& sg
+);
+
 void lct_arm_at(lowres_clock_timer& timer, int64_t at);
 
 void lct_arm_at_periodic(lowres_clock_timer& timer, int64_t ay, int64_t period);
@@ -76,6 +94,14 @@ void mct_set_callback(
     uint8_t* callback, // uint8_t is a substitute for void that isn't supported by cxx.
     rust::Fn<void(uint8_t*)> caller,
     rust::Fn<void(uint8_t*)> dropper
+);
+
+void mct_set_callback_under_group(
+    manual_clock_timer& timer,
+    uint8_t* callback,
+    rust::Fn<void(uint8_t*)> caller,
+    rust::Fn<void(uint8_t*)> dropper,
+    const scheduling_group& sg
 );
 
 void mct_arm_at(manual_clock_timer& timer, int64_t at);

--- a/seastar/src/timer.rs
+++ b/seastar/src/timer.rs
@@ -304,6 +304,24 @@ mod tests {
                 }
 
                 #[seastar::test]
+                async fn [<test_ $timer _set_callback_under_group>]() {
+                    let mut timer = Timer::<$Clock>::new();
+
+                    let calls = Rc::new(RefCell::new(0));
+                    let calls_cloned = calls.clone();
+                    let callback = move || {
+                        *calls_cloned.borrow_mut() += 1;
+                    };
+                    let sg = SchedulingGroup::create("sg", 100.).await;
+                    timer.set_callback_under_group(callback, &sg);
+
+                    let duration = Duration::from_millis(100);
+                    timer.arm(duration);
+
+                    [<check_ $timer>](&mut timer, duration, calls).await;
+                }
+
+                #[seastar::test]
                 async fn [<test_ $timer _arm_at>]() {
                     let (mut timer, duration, calls) = [<set_up_ $timer _test>]();
 

--- a/seastar/src/timer.rs
+++ b/seastar/src/timer.rs
@@ -1,5 +1,6 @@
 use crate::assert_runtime_is_running;
 use crate::ffi_utils::{get_dropper, get_fn_mut_void_caller};
+use crate::SchedulingGroup;
 use crate::{Clock, Duration, Instant};
 use std::marker::PhantomData;
 
@@ -91,6 +92,23 @@ impl<ClockType: Clock> Timer<ClockType> {
         let dropper = get_dropper(&callback);
         let boxed_callback = Box::into_raw(Box::new(callback)) as *mut u8;
         ClockType::set_callback(&mut self.inner, boxed_callback, caller, dropper);
+    }
+
+    /// Sets the callback function to be called under specified group when
+    /// the timer expires.
+    ///
+    /// # Arguments
+    /// * `callback` - The callback to be executed when the timer expires.
+    /// * `sg` - The scheduling group under which the callback will be executed.
+    pub fn set_callback_under_group<Func: FnMut() + 'static>(
+        &mut self,
+        callback: Func,
+        sg: &SchedulingGroup,
+    ) {
+        let caller = get_fn_mut_void_caller(&callback);
+        let dropper = get_dropper(&callback);
+        let boxed_callback = Box::into_raw(Box::new(callback)) as *mut u8;
+        ClockType::set_callback_under_group(&mut self.inner, boxed_callback, caller, dropper, &sg);
     }
 
     /// Sets the timer expiration time.


### PR DESCRIPTION
fixes: #33
depends on and finishes: #32

This PR exposes a simplified version of the API implemented in [scheduling.hh](https://github.com/scylladb/seastar/blob/master/include/seastar/core/scheduling.hh) and uses it to finish timer specializations.

## Scheduling API

The `scheduling_group` class is exposed as a struct called `SchedulingGroup` along with its methods except `get_specific`. Operators `==` and `!=` are expressed in Rust by implementing the Eq trait. The public constructor and the `default_scheduling_group` function (both of them do the same thing) are expressed by implementing the Default trait.

Apart from the `scheduling_group` class, the following functions are exposed:
- `create_scheduling_group`,
- `delete_scheduling_group`,
- `rename_scheduling_group`,
- `max_scheduling_groups` (we lose `constexpr` but I don't think it's a problem),
- `current_scheduling_group`.

All of them are implemented in Rust as methods or associated functions of the `SchedulingGroup` struct. C++ passes `scheduling_group` by value to every function but I think we want to use references in Rust (edit: I think this approach is wrong, I've explained it in a new comment).

Class `scheduling_group` has a method `set_shares` that is not `const`. I don't think expressing this in Rust by requiring `&mut self` is a good idea. This single method would make our API much harder to use. I think that using `&self` everywhere is completely fine because `SchedulingGroup` can be considered as just a flag that doesn't change and only provides an interface.

## Finishing timer

This PR also adds a method called `set_callback_under_group`to all 3 timer specializations. To implement this method, it was necessary to expose `scheduling_group` first. This feature makes `seastar::timer`'s functionality fully exposed.

## The rest of the scheduling API

As described here #33, we don't want to expose the rest of the scheduling API to Rust for now.