### PR TITLE
Submit to

### DIFF
--- a/seastar/build.rs
+++ b/seastar/build.rs
@@ -6,12 +6,14 @@ static CXX_BRIDGES: &[&str] = &[
     "src/config_and_start_seastar.rs",
     "src/api_safety.rs",
     "src/spawn.rs",
+    "src/submit_to.rs",
 ];
 
 static CXX_CPP_SOURCES: &[&str] = &[
     // Put all cpp source files into this list
     "src/config_and_start_seastar.cc",
     "src/spawn.cc",
+    "src/submit_to.cc",
 ];
 
 fn main() {

--- a/seastar/src/ffi_utils.rs
+++ b/seastar/src/ffi_utils.rs
@@ -1,0 +1,27 @@
+/// Convert the pointer to Box<Func> and then call it, consuming it in the process.
+fn fn_once_caller<Func, Ret>(raw_func: *mut u8) -> Ret
+where
+    Func: FnOnce() -> Ret,
+{
+    unsafe { Box::from_raw(raw_func as *mut Func)() }
+}
+
+/// A helper function. We need to be able to name the type of a named closure.
+/// There is no `typeof` in Rust, so this is achieved by using a dummy parameter.
+pub const fn get_fn_once_caller<Func, Ret>(_: &Func) -> fn(*mut u8) -> Ret
+where
+    Func: FnOnce() -> Ret,
+{
+    fn_once_caller::<Func, Ret>
+}
+
+/// Free a pointer.
+fn dropper<T>(raw_ptr: *mut u8) {
+    unsafe {
+        let _ = Box::from_raw(raw_ptr as *mut T);
+    }
+}
+
+pub const fn get_dropper<T>(_: &T) -> fn(*mut u8) {
+    dropper::<T>
+}

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -6,10 +6,12 @@ mod api_safety;
 mod config_and_start_seastar;
 mod cxx_async_futures;
 mod cxx_async_local_future;
+mod ffi_utils;
 mod preempt;
 #[cfg(test)]
 pub(crate) mod seastar_test_guard;
 mod spawn;
+mod submit_to;
 
 #[cfg(test)]
 pub(crate) use seastar_test_guard::acquire_guard_for_seastar_test;
@@ -18,6 +20,7 @@ pub use api_safety::*;
 pub use config_and_start_seastar::*;
 pub use preempt::*;
 pub use spawn::*;
+pub use submit_to::*;
 
 /// A macro intended for running asynchronous tests.
 ///

--- a/seastar/src/submit_to.cc
+++ b/seastar/src/submit_to.cc
@@ -1,0 +1,16 @@
+#include "submit_to.hh"
+#include <seastar/core/smp.hh>
+
+namespace seastar_ffi {
+
+namespace submit_to {
+
+VoidFuture submit_to(const uint32_t shard_id, uint8_t* closure, rust::Fn<VoidFuture(uint8_t*)> caller) {
+    co_await ::seastar::smp::submit_to(shard_id, [&] () -> seastar::future<> {
+        co_await caller(closure);
+    });
+}
+
+} // submit_to
+
+} // seastar_ffi

--- a/seastar/src/submit_to.hh
+++ b/seastar/src/submit_to.hh
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "cxx-async/include/rust/cxx_async_seastar.h"
+#include "rust/cxx.h"
+#include "cxx_async_futures.hh"
+
+namespace seastar_ffi {
+
+namespace submit_to {
+
+using fn_once_caller_t = VoidFuture (*)(const uint8_t*);
+
+VoidFuture submit_to(const uint32_t shard_id, uint8_t* closure, rust::Fn<VoidFuture(uint8_t*)> caller);
+
+} // submit_to
+
+} // seastar_ffi

--- a/seastar/src/submit_to.rs
+++ b/seastar/src/submit_to.rs
@@ -1,0 +1,95 @@
+use crate as seastar;
+use crate::ffi_utils::{get_dropper, get_fn_once_caller};
+use ffi::*;
+use std::future::Future;
+
+use crate::cxx_async_local_future::IntoCxxAsyncLocalFuture;
+
+#[cxx::bridge]
+mod ffi {
+    #[namespace = "seastar_ffi"]
+    unsafe extern "C++" {
+        type VoidFuture = crate::cxx_async_futures::VoidFuture;
+    }
+
+    #[namespace = "seastar_ffi::submit_to"]
+    unsafe extern "C++" {
+        include!("seastar/src/submit_to.hh");
+
+        unsafe fn submit_to(
+            shard_id: u32,
+            closure: *mut u8,
+            caller: unsafe fn(*mut u8) -> VoidFuture,
+        ) -> VoidFuture;
+    }
+}
+
+/// Runs a function `func` on a `shard_id` shard.
+///
+/// # Example
+///
+/// ```rust
+/// #[seastar::test]
+/// async fn submit_to_example() {
+///     let ret = submit_to(0, || async { 42 }).await;
+///     assert!(matches!(ret, 42));
+/// }
+pub async fn submit_to<Func, Fut, Ret>(shard_id: u32, func: Func) -> Ret
+where
+    Func: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = Ret> + 'static,
+    Ret: Send + 'static,
+{
+    let (tx, rx) = futures::channel::oneshot::channel::<Ret>();
+
+    let closure = move || {
+        VoidFuture::infallible_local(async {
+            tx.send(func().await).ok();
+        })
+    };
+
+    let closure_caller = get_fn_once_caller(&closure);
+    let dropper = get_dropper(&closure);
+    let boxed_closure = Box::into_raw(Box::new(closure)) as *mut u8;
+
+    unsafe {
+        match ffi::submit_to(shard_id, boxed_closure, closure_caller).await {
+            Ok(_) => rx.await.unwrap(),
+            Err(_) => {
+                dropper(boxed_closure);
+                panic!()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[seastar::test]
+    async fn test_submit_to() {
+        let ret = submit_to(0, || async { 42 }).await;
+        assert!(matches!(ret, 42));
+    }
+
+    #[seastar::test]
+    async fn test_submit_to_nested() {
+        let ret = submit_to(0, || async { submit_to(0, || async { 42 }).await }).await;
+        assert!(matches!(ret, 42));
+    }
+
+    #[seastar::test]
+    async fn test_submit_to_two_shards() {
+        let ret = submit_to(0, || async { 17 }).await;
+        assert!(matches!(ret, 17));
+        let ret = submit_to(1, || async { 25 }).await;
+        assert!(matches!(ret, 25));
+    }
+
+    #[seastar::test]
+    async fn test_submit_to_two_shards_nested() {
+        let ret = submit_to(1, || async { submit_to(0, || async { 42 }).await }).await;
+        assert!(matches!(ret, 42));
+    }
+}


### PR DESCRIPTION
Fixes: #15 
Depends on: #2 

This PR introduces a way to run code on a specific shard by method:
```rust
pub async fn submit_to<Func, Fut, Ret>(shard_id: u32, func: Func) -> Ret
where
    Func: FnOnce() -> Fut + Send + 'static,
    Fut: Future<Output = Ret> + 'static,
    Ret: Send + 'static,
```
For example:
```rust
let _ = submit_to(0, || async { 42 }).await;
```