### PR TITLE
CI: run `apt update` before installing anything

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,11 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Update apt
+      run: sudo apt update
     - name: Install lld
-      run: |
-        sudo apt install lld
-        sudo apt install libunistring-dev
-        sudo apt install libudev-dev
+      run: sudo apt install lld libunistring-dev libudev-dev
     - name: Install Seastar
       run: |
         cd ..


### PR DESCRIPTION
It is possible for the test runner's apt index to become stale, which can lead to apt trying to download files from URLs that don't exist. Fix that by always running `apt update` before continuing with installation of packages necessary for compilation.