### PR TITLE
Expose `seastar::distributed`

### DIFF
--- a/seastar/build.rs
+++ b/seastar/build.rs
@@ -10,6 +10,7 @@ static CXX_BRIDGES: &[&str] = &[
     "src/gate.rs",
     "src/clocks.rs",
     "src/smp.rs",
+    "src/distributed.rs",
 ];
 
 static CXX_CPP_SOURCES: &[&str] = &[
@@ -21,6 +22,7 @@ static CXX_CPP_SOURCES: &[&str] = &[
     "src/clocks.cc",
     "src/sleep.cc",
     "src/smp.cc",
+    "src/distributed.cc",
 ];
 
 fn main() {

--- a/seastar/build.rs
+++ b/seastar/build.rs
@@ -9,6 +9,7 @@ static CXX_BRIDGES: &[&str] = &[
     "src/submit_to.rs",
     "src/gate.rs",
     "src/clocks.rs",
+    "src/smp.rs",
 ];
 
 static CXX_CPP_SOURCES: &[&str] = &[
@@ -19,6 +20,7 @@ static CXX_CPP_SOURCES: &[&str] = &[
     "src/gate.cc",
     "src/clocks.cc",
     "src/sleep.cc",
+    "src/smp.cc",
 ];
 
 fn main() {

--- a/seastar/src/distributed.cc
+++ b/seastar/src/distributed.cc
@@ -1,0 +1,66 @@
+#include "distributed.hh"
+#include <seastar/util/defer.hh>
+
+namespace seastar_ffi {
+namespace distributed {
+
+rust_service::rust_service(
+    const uint8_t* raw_service_maker,
+    rust::Fn<uint8_t*(const uint8_t*)> raw_service_maker_caller,
+    rust::Fn<VoidFuture(uint8_t*)> stop_caller,
+    rust::Fn<void(uint8_t*)> dropper)
+: _stop_caller(stop_caller), _dropper(dropper)
+{
+    _inner = raw_service_maker_caller(raw_service_maker);
+}
+
+seastar::future<> rust_service::stop() {
+    co_await _stop_caller(_inner);
+}
+
+rust_service::~rust_service() {
+    _dropper(_inner);
+}
+
+std::shared_ptr<distributed> new_distributed() {
+    return std::make_shared<distributed>();
+}
+
+const uint8_t* local(const distributed& distr) {
+    return distr.local()._inner;
+}
+
+VoidFuture start(
+    const distributed& distr,
+    const uint8_t* raw_service_maker,
+    rust::Fn<uint8_t*(const uint8_t*)> raw_service_maker_caller,
+    rust::Fn<void(const uint8_t*)> raw_service_maker_dropper,
+    rust::Fn<VoidFuture(uint8_t*)> stop_caller,
+    rust::Fn<void(uint8_t*)> dropper
+) {
+    auto cleanup_maker = seastar::defer([&] {
+        raw_service_maker_dropper(raw_service_maker);
+    });
+    co_await const_cast<distributed&>(distr).start(raw_service_maker, raw_service_maker_caller, stop_caller, dropper);
+}
+
+VoidFuture start_single(
+    const distributed& distr,
+    const uint8_t* raw_service_maker,
+    rust::Fn<uint8_t*(const uint8_t*)> raw_service_maker_caller,
+    rust::Fn<void(const uint8_t*)> raw_service_maker_dropper,
+    rust::Fn<VoidFuture(uint8_t*)> stop_caller,
+    rust::Fn<void(uint8_t*)> dropper
+) {
+    auto cleanup_maker = seastar::defer([&] {
+        raw_service_maker_dropper(raw_service_maker);
+    });
+    co_await const_cast<distributed&>(distr).start_single(raw_service_maker, raw_service_maker_caller, stop_caller, dropper);
+}
+
+VoidFuture stop(const distributed& distr) {
+    co_await const_cast<distributed&>(distr).stop();
+}
+
+} // namespace distributed
+} // namespace seastar_ffi

--- a/seastar/src/distributed.hh
+++ b/seastar/src/distributed.hh
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "cxx_async_futures.hh"
+#include <seastar/core/distributed.hh>
+
+namespace seastar_ffi {
+namespace distributed {
+
+class rust_service {
+private:
+    rust::Fn<VoidFuture(uint8_t*)> _stop_caller;
+    rust::Fn<void(uint8_t*)> _dropper;
+public:
+    uint8_t* _inner;
+
+    rust_service(
+        const uint8_t* raw_service_maker,
+        rust::Fn<uint8_t*(const uint8_t*)> raw_service_maker_caller,
+        rust::Fn<VoidFuture(uint8_t*)> stop_caller,
+        rust::Fn<void(uint8_t*)> dropper
+    );
+    ~rust_service();
+
+    seastar::future<> stop();
+};
+
+using distributed = seastar::distributed<rust_service>;
+
+std::shared_ptr<distributed> new_distributed();
+
+const uint8_t* local(const distributed& distr);
+
+VoidFuture start(
+    const distributed& distr,
+    const uint8_t* raw_service_maker,
+    rust::Fn<uint8_t*(const uint8_t*)> raw_service_maker_caller,
+    rust::Fn<void(const uint8_t*)> raw_service_maker_dropper,
+    rust::Fn<VoidFuture(uint8_t*)> stop_caller,
+    rust::Fn<void(uint8_t*)> dropper
+);
+
+VoidFuture start_single(
+    const distributed& distr,
+    const uint8_t* raw_service_maker,
+    rust::Fn<uint8_t*(const uint8_t*)> raw_service_maker_caller,
+    rust::Fn<void(const uint8_t*)> raw_service_maker_dropper,
+    rust::Fn<VoidFuture(uint8_t*)> stop_caller,
+    rust::Fn<void(uint8_t*)> dropper
+);
+
+VoidFuture stop(const distributed &distr);
+
+} // namespace distributed
+} // namespace seastar_ffi

--- a/seastar/src/distributed.rs
+++ b/seastar/src/distributed.rs
@@ -1,0 +1,517 @@
+use crate::{
+    cxx_async_local_future::IntoCxxAsyncLocalFuture,
+    ffi_utils::{get_dropper_const, get_dropper_noarg, get_fn_caller},
+    get_count,
+    submit_to::submit_to,
+    this_shard_id,
+};
+use core::marker::PhantomData;
+use cxx::SharedPtr;
+use std::future::Future;
+use std::pin::Pin;
+
+#[cxx::bridge(namespace = "seastar_ffi::distributed")]
+mod ffi {
+    unsafe extern "C++" {
+        include!("seastar/src/distributed.hh");
+
+        type distributed;
+
+        #[namespace = "seastar_ffi"]
+        type VoidFuture = crate::cxx_async_futures::VoidFuture;
+
+        fn new_distributed() -> SharedPtr<distributed>;
+
+        fn local(distr: &distributed) -> *const u8;
+
+        unsafe fn start(
+            distr: &distributed,
+            raw_service_maker: *const u8,
+            raw_service_maker_caller: unsafe fn(*const u8) -> *mut u8,
+            raw_service_maker_droppper: unsafe fn(*const u8),
+            stop_caller: unsafe fn(*mut u8) -> VoidFuture,
+            dropper: unsafe fn(*mut u8),
+        ) -> VoidFuture;
+
+        unsafe fn start_single(
+            distr: &distributed,
+            raw_service_maker: *const u8,
+            raw_service_maker_caller: unsafe fn(*const u8) -> *mut u8,
+            raw_service_maker_droppper: unsafe fn(*const u8),
+            stop_caller: unsafe fn(*mut u8) -> VoidFuture,
+            dropper: unsafe fn(*mut u8),
+        ) -> VoidFuture;
+
+        fn stop(distr: &distributed) -> VoidFuture;
+    }
+}
+
+fn stop_caller<S: Service>(raw_service: *mut u8) -> VoidFuture {
+    VoidFuture::infallible_local(async move {
+        let stop_future = unsafe { (raw_service as *mut S).as_mut().unwrap().stop() };
+        Pin::from(stop_future).await;
+    })
+}
+
+const fn get_stop_caller<S: Service>() -> fn(*mut u8) -> VoidFuture {
+    stop_caller::<S>
+}
+
+use ffi::{distributed, VoidFuture};
+
+unsafe impl Send for distributed {}
+unsafe impl Sync for distributed {}
+
+/// A trait which a service inside `Distributed` must implement.
+///
+/// Because of Rust not yet supporting `async` trait methods,
+/// or trait methods that return an `impl` (`impl Future`) in this case,
+/// the returned future must be `Box`ed.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::future::Future;
+/// use seastar::Service;
+///
+/// struct FooService;
+///
+/// impl Service for FooService {
+///     fn stop(&self) -> Box<dyn Future<Output = ()>> {
+///         Box::new(async { println!("Shutting down!") })
+///     }
+/// }
+/// ```
+pub trait Service {
+    /// The place to define what (possibly asynchronous) cleanup must be done for the service.
+    ///
+    /// If not implemented, defaults to a no-op.
+    fn stop(&self) -> Box<dyn Future<Output = ()>> {
+        Box::new(async {})
+    }
+}
+
+/// A service distributed amongst all shards of a Seastar app.
+///
+/// You can use this to, for example, load balance a local storage.
+pub struct Distributed<S: Service> {
+    _inner: SharedPtr<distributed>,
+    _ty: PhantomData<S>,
+}
+
+impl<S: Service> Distributed<S> {
+    /// Returns a reference to the underlying service on the current shard.
+    ///
+    pub fn local(&self) -> &S {
+        let local = ffi::local(self._inner.as_ref().unwrap());
+        unsafe { &*(local as *const S) }
+    }
+
+    fn start_inner<Func>(service_maker: Func, single: bool) -> impl Future<Output = Self>
+    where
+        Func: Fn() -> S + Sync,
+    {
+        let stop_caller = get_stop_caller::<S>();
+        let dropper = get_dropper_noarg::<S>();
+
+        let raw_service_maker = move || Box::into_raw(Box::new(service_maker())) as *mut u8;
+        let raw_service_maker_caller = get_fn_caller(&raw_service_maker);
+        let raw_service_maker_dropper = get_dropper_const(&raw_service_maker);
+        let boxed_raw_service_maker = Box::into_raw(Box::new(raw_service_maker)) as *const u8;
+
+        let distr = ffi::new_distributed();
+        let fut = unsafe {
+            if single {
+                ffi::start_single(
+                    distr.as_ref().unwrap(),
+                    boxed_raw_service_maker,
+                    raw_service_maker_caller,
+                    raw_service_maker_dropper,
+                    stop_caller,
+                    dropper,
+                )
+            } else {
+                ffi::start(
+                    distr.as_ref().unwrap(),
+                    boxed_raw_service_maker,
+                    raw_service_maker_caller,
+                    raw_service_maker_dropper,
+                    stop_caller,
+                    dropper,
+                )
+            }
+        };
+
+        async move {
+            match fut.await {
+                Ok(_) => Distributed {
+                    _inner: distr,
+                    _ty: PhantomData,
+                },
+                Err(_) => panic!(),
+            }
+        }
+    }
+
+    /// Starts a single instance of the service on shard `0`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::future::Future;
+    /// use std::sync::atomic::{AtomicU32, Ordering};
+    /// use std::sync::Arc;
+    /// use seastar::{Distributed, Service};
+    ///
+    /// struct CounterService(Arc<AtomicU32>);
+    ///
+    /// impl Service for CounterService {
+    ///     fn stop(&self) -> Box<dyn Future<Output = ()>> {
+    ///         let counter = self.0.clone();
+    ///         Box::new(async move {
+    ///             counter.fetch_add(1, Ordering::SeqCst);
+    ///         })
+    ///     }
+    /// }
+    ///
+    /// #[seastar::test]
+    /// async fn test_start_single_and_stop() {
+    ///     let counter_clone = counter.clone();
+    ///     let service_maker = move || CounterService(counter_clone.clone());
+    ///     let distr = Distributed::start_single(service_maker).await;
+    ///     distr.stop().await;
+    ///     assert_eq!(1, counter.load(Ordering::SeqCst));
+    /// }
+    /// ```
+    pub fn start_single<Func>(service_maker: Func) -> impl Future<Output = Self>
+    where
+        Func: Fn() -> S + Sync,
+    {
+        Distributed::start_inner(service_maker, true)
+    }
+
+    /// Starts an instance of the service on each shard.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::future::Future;
+    /// use std::sync::atomic::{AtomicU32, Ordering};
+    /// use std::sync::Arc;
+    /// use seastar::{get_count, Distributed, Service};
+    ///
+    /// struct CounterService(Arc<AtomicU32>);
+    ///
+    /// impl Service for CounterService {
+    ///     fn stop(&self) -> Box<dyn Future<Output = ()>> {
+    ///         let counter = self.0.clone();
+    ///         Box::new(async move {
+    ///             counter.fetch_add(1, Ordering::SeqCst);
+    ///         })
+    ///     }
+    /// }
+    ///
+    /// #[seastar::test]
+    /// async fn test_start_and_stop() {
+    ///     let counter: Arc<AtomicU32> = Default::default();
+    ///     let counter_clone = counter.clone();
+    ///     let service_maker = move || CounterService(counter_clone.clone());
+    ///     let distr = Distributed::start(service_maker).await;
+    ///     distr.stop().await;
+    ///     assert_eq!(get_count(), counter.load(Ordering::SeqCst));
+    /// }
+    /// ```
+    pub fn start<Func>(service_maker: Func) -> impl Future<Output = Self>
+    where
+        Func: Fn() -> S + Sync,
+    {
+        Distributed::start_inner(service_maker, false)
+    }
+
+    /// Stops the service on all shards on which it was ran, freeing each instance's memory. Effectively an async destructor.
+    ///
+    /// This **must** be called when the distributed service is no longer to be used!.
+    ///
+    /// ```rust
+    /// use std::future::Future;
+    /// use std::sync::atomic::{AtomicU32, Ordering};
+    /// use std::sync::Arc;
+    /// use seastar::{Distributed, Service};
+    ///
+    /// struct CounterService(Arc<AtomicU32>);
+    ///
+    /// impl Service for CounterService {
+    ///     fn stop(&self) -> Box<dyn Future<Output = ()>> {
+    ///         let counter = self.0.clone();
+    ///         Box::new(async move {
+    ///             counter.fetch_add(1, Ordering::SeqCst);
+    ///         })
+    ///     }
+    /// }
+    ///
+    /// #[seastar::test]
+    /// async fn test_start_single_and_stop() {
+    ///     let counter_clone = counter.clone();
+    ///     let service_maker = move || CounterService(counter_clone.clone());
+    ///     let distr = Distributed::start_single(service_maker).await;
+    ///     distr.stop().await;
+    ///     assert_eq!(1, counter.load(Ordering::SeqCst));
+    /// }
+    /// ```
+    pub async fn stop(&self) {
+        ffi::stop(self._inner.as_ref().unwrap()).await.unwrap();
+    }
+
+    fn map_selected<'a, Func, Fut, Ret, I>(
+        &'a self,
+        func: Func,
+        shards: I,
+    ) -> Vec<impl Future<Output = Ret>>
+    where
+        Func: Fn(&'a S) -> Fut + Send + Clone + 'static,
+        Fut: Future<Output = Ret>,
+        Ret: Send + 'static,
+        I: IntoIterator<Item = u32>,
+    {
+        shards
+            .into_iter()
+            .map(|shard| (shard, func.clone(), self._inner.clone()))
+            .map(|(shard, func, inner)| async move {
+                submit_to(shard, || async move {
+                    let local = ffi::local(inner.as_ref().unwrap());
+                    let local = unsafe { &*(local as *const S) };
+                    func(local).await
+                })
+                .await
+            })
+            .collect()
+    }
+
+    /// Applies a map function to all instances of the service and returns a vector of the results.
+    ///
+    /// Equivalent to `seastar::distributed::map`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::sync::atomic::{AtomicU32, Ordering};
+    /// use std::sync::Arc;
+    /// use futures::future::join_all;
+    /// use seastar::{get_count, Distributed, Service};
+    ///
+    /// struct CounterService(Arc<AtomicU32>);
+    ///
+    /// impl CounterService {
+    ///     async fn inc(&self) {
+    ///         self.0.fetch_add(1, Ordering::SeqCst);
+    ///     }
+    /// }
+    ///
+    /// impl Service for CounterService {}
+    ///
+    /// #[seastar::test]
+    /// async fn test_map_all() {
+    ///     let counter: Arc<AtomicU32> = Default::default();
+    ///     let counter_clone = counter.clone();
+    ///     let service_maker = move || CounterService(counter_clone.clone());
+    ///     let distr = Distributed::start(service_maker).await;
+    ///     
+    ///     let futs = distr.map_all(CounterService::inc);
+    ///     join_all(futs).await;
+    ///     distr.stop().await;
+    ///     
+    ///     assert_eq!(2 * get_count(), counter.load(Ordering::SeqCst));
+    /// }
+    /// ```
+    pub fn map_all<'a, Func, Ret, Fut>(&'a self, func: Func) -> Vec<impl Future<Output = Ret>>
+    where
+        Func: Fn(&'a S) -> Fut + Send + Clone + 'static,
+        Fut: Future<Output = Ret>,
+        Ret: Send + 'static,
+    {
+        self.map_selected(func, 0..get_count())
+    }
+
+    /// Applies a map function to all instances of the service, except the one on the current shard, and returns a vector of the results.
+    ///
+    /// Spiritually, a hybrid of `seastar::distributed::map` and `seastar::distributed::invoke_on_others`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::sync::atomic::{AtomicU32, Ordering};
+    /// use std::sync::Arc;
+    /// use futures::future::join_all;
+    /// use seastar::{get_count, Distributed, Service};
+    ///
+    /// struct CounterService(Arc<AtomicU32>);
+    ///
+    /// impl CounterService {
+    ///     async fn inc(&self) {
+    ///         self.0.fetch_add(1, Ordering::SeqCst);
+    ///     }
+    /// }
+    ///
+    /// impl Service for CounterService {}
+    ///
+    /// #[seastar::test]
+    /// async fn test_map_others() {
+    ///     let counter: Arc<AtomicU32> = Default::default();
+    ///     let counter_clone = counter.clone();
+    ///     let service_maker = move || CounterService(counter_clone.clone());
+    ///     let distr = Distributed::start(service_maker).await;
+    ///     
+    ///     let futs = distr.map_others(CounterService::inc);
+    ///     join_all(futs).await;
+    ///     distr.stop().await;
+    ///     
+    ///     assert_eq!(2 * get_count() - 1, counter.load(Ordering::SeqCst));
+    /// }
+    /// ```
+    pub fn map_others<'a, Func, Ret, Fut>(&'a self, func: Func) -> Vec<impl Future<Output = Ret>>
+    where
+        Func: Fn(&'a S) -> Fut + Send + Clone + 'static,
+        Fut: Future<Output = Ret>,
+        Ret: Send + 'static,
+    {
+        let this_shard = this_shard_id();
+        self.map_selected(func, (0..get_count()).filter(move |sh| sh.ne(&this_shard)))
+    }
+
+    /// Applies a map function only to the service instance on the provided shard.
+    ///
+    /// Spiritually, a hybrid of `seastar::distributed::map` and `seastar::distributed::invoke_on`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::sync::atomic::{AtomicU32, Ordering};
+    /// use std::sync::Arc;
+    /// use seastar::{get_count, Distributed, Service};
+    ///
+    /// struct CounterService(Arc<AtomicU32>);
+    ///
+    /// impl CounterService {
+    ///     async fn inc(&self) {
+    ///         self.0.fetch_add(1, Ordering::SeqCst);
+    ///     }
+    /// }
+    ///
+    /// impl Service for CounterService {}
+    ///
+    /// #[seastar::test]
+    /// async fn test_map_single() {
+    ///     let counter: Arc<AtomicU32> = Default::default();
+    ///     let counter_clone = counter.clone();
+    ///     let service_maker = move || CounterService(counter_clone.clone());
+    ///     let distr = Distributed::start(service_maker).await;
+    ///     
+    ///     for shard in 0..get_count() {
+    ///         distr.map_single(shard, CounterService::inc).await;
+    ///         assert_eq!(shard + 1, counter.load(Ordering::SeqCst));
+    ///     }
+    ///     distr.stop().await;
+    /// }
+    /// ```
+    pub fn map_single<'a, Func, Ret, Fut>(
+        &'a self,
+        shard_id: u32,
+        func: Func,
+    ) -> impl Future<Output = Ret>
+    where
+        Func: Fn(&'a S) -> Fut + Send + Clone + 'static,
+        Fut: Future<Output = Ret>,
+        Ret: Send + 'static,
+    {
+        self.map_selected(func, std::iter::once(shard_id)).remove(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::future::join_all;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    use super::*;
+    use crate as seastar;
+
+    struct CounterService(Arc<AtomicU32>);
+
+    impl CounterService {
+        async fn inc(&self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl Service for CounterService {
+        fn stop(&self) -> Box<dyn Future<Output = ()>> {
+            let counter = self.0.clone();
+            Box::new(async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+            })
+        }
+    }
+
+    #[seastar::test]
+    async fn test_start_single_and_stop() {
+        let counter: Arc<AtomicU32> = Default::default();
+        let counter_clone = counter.clone();
+        let service_maker = move || CounterService(counter_clone.clone());
+        let distr = Distributed::start_single(service_maker).await;
+        distr.stop().await;
+        assert_eq!(1, counter.load(Ordering::SeqCst));
+    }
+
+    #[seastar::test]
+    async fn test_start_and_stop() {
+        let counter: Arc<AtomicU32> = Default::default();
+        let counter_clone = counter.clone();
+        let service_maker = move || CounterService(counter_clone.clone());
+        let distr = Distributed::start(service_maker).await;
+        distr.stop().await;
+        assert_eq!(get_count(), counter.load(Ordering::SeqCst));
+    }
+
+    #[seastar::test]
+    async fn test_map_all() {
+        let counter: Arc<AtomicU32> = Default::default();
+        let counter_clone = counter.clone();
+        let service_maker = move || CounterService(counter_clone.clone());
+        let distr = Distributed::start(service_maker).await;
+
+        let futs = distr.map_all(CounterService::inc);
+        join_all(futs).await;
+        distr.stop().await;
+
+        assert_eq!(2 * get_count(), counter.load(Ordering::SeqCst));
+    }
+
+    #[seastar::test]
+    async fn test_map_others() {
+        let counter: Arc<AtomicU32> = Default::default();
+        let counter_clone = counter.clone();
+        let service_maker = move || CounterService(counter_clone.clone());
+        let distr = Distributed::start(service_maker).await;
+
+        let futs = distr.map_others(CounterService::inc);
+        join_all(futs).await;
+        distr.stop().await;
+
+        assert_eq!(2 * get_count() - 1, counter.load(Ordering::SeqCst));
+    }
+
+    #[seastar::test]
+    async fn test_map_single() {
+        let counter: Arc<AtomicU32> = Default::default();
+        let counter_clone = counter.clone();
+        let service_maker = move || CounterService(counter_clone.clone());
+        let distr = Distributed::start(service_maker).await;
+
+        for shard in 0..get_count() {
+            distr.map_single(shard, CounterService::inc).await;
+            assert_eq!(shard + 1, counter.load(Ordering::SeqCst));
+        }
+        distr.stop().await;
+    }
+}

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -15,6 +15,7 @@ pub(crate) mod seastar_test_guard;
 mod sleep;
 mod spawn;
 mod submit_to;
+mod smp;
 
 #[cfg(test)]
 pub(crate) use seastar_test_guard::acquire_guard_for_seastar_test;
@@ -27,6 +28,7 @@ pub use preempt::*;
 pub use sleep::*;
 pub use spawn::*;
 pub use submit_to::*;
+pub use smp::*;
 
 /// A macro intended for running asynchronous tests.
 ///

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -7,15 +7,16 @@ mod clocks;
 mod config_and_start_seastar;
 mod cxx_async_futures;
 mod cxx_async_local_future;
+mod distributed;
 mod ffi_utils;
 mod gate;
 mod preempt;
 #[cfg(test)]
 pub(crate) mod seastar_test_guard;
 mod sleep;
+mod smp;
 mod spawn;
 mod submit_to;
-mod smp;
 
 #[cfg(test)]
 pub(crate) use seastar_test_guard::acquire_guard_for_seastar_test;
@@ -23,12 +24,13 @@ pub(crate) use seastar_test_guard::acquire_guard_for_seastar_test;
 pub use api_safety::*;
 pub use clocks::*;
 pub use config_and_start_seastar::*;
+pub use distributed::*;
 pub use gate::*;
 pub use preempt::*;
 pub use sleep::*;
+pub use smp::*;
 pub use spawn::*;
 pub use submit_to::*;
-pub use smp::*;
 
 /// A macro intended for running asynchronous tests.
 ///

--- a/seastar/src/smp.cc
+++ b/seastar/src/smp.cc
@@ -1,0 +1,12 @@
+#include "smp.hh"
+#include <seastar/core/smp.hh>
+
+namespace seastar_ffi {
+namespace smp {
+
+uint32_t get_count() {
+    return (uint32_t)seastar::smp::count;
+}
+
+} // namespace smp
+} // namespace seastar_ffi

--- a/seastar/src/smp.hh
+++ b/seastar/src/smp.hh
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+
+namespace seastar_ffi {
+namespace smp {
+
+uint32_t get_count();
+
+} // namespace smp
+} // namespace seastar_ffi

--- a/seastar/src/smp.rs
+++ b/seastar/src/smp.rs
@@ -1,0 +1,42 @@
+#[cxx::bridge]
+mod ffi {
+    #[namespace = "seastar"]
+    unsafe extern "C++" {
+        include!("seastar/core/smp.hh");
+
+        /// Returns the `shard_id` of the current shard.
+        fn this_shard_id() -> u32;
+    }
+
+    #[namespace = "seastar_ffi::smp"]
+    unsafe extern "C++" {
+        include!("seastar/src/smp.hh");
+
+        /// Returns the total number of shards.
+        fn get_count() -> u32;
+    }
+}
+
+pub use ffi::{get_count, this_shard_id};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate as seastar;
+
+    #[test]
+    fn test_this_shard_id() {
+        assert_eq!(this_shard_id(), 0);
+    }
+
+    #[seastar::test]
+    async fn test_get_count_within_runtime() {
+        // `num_cpus::get` is inconsistent with regards to cpu affinity,
+        // see the discussion here: https://github.com/seanmonstar/num_cpus/pull/38
+        // Thus, checking if *any* shards were created has to do for now.
+        assert_ne!(get_count(), 0);
+        // Outside of `AppTemplate::run{int, void}`, the function will yield 0,
+        // but this is not tested here, as there's no control over the order of tests,
+        // and Seastar doesn't clean up the variable that stores the cpu count (`seastar::smp::count`).
+    }
+}


### PR DESCRIPTION
Resolves: #21 

This PR exposes the [`seastar::distributed<S>`](https://github.com/scylladb/seastar/blob/master/include/seastar/core/distributed.hh) API, an alias for `seastar::sharded<S>`, as `Distributed<S>`.

In Seastar, the type over which `distributed` is generic must expose a `stop`, which is expressed by the following snippet in `sharded.hh`:
```cpp
// Helper check if Service::stop exists

struct sharded_has_stop {
    // If a member names "stop" exists, try to call it, even if it doesn't
    // have the correct signature. This is so that we don't ignore a function
    // named stop() just because the signature is incorrect, and instead
    // force the user to resolve the ambiguity.
    template <typename Service>
    constexpr static auto check(int) -> std::enable_if_t<(sizeof(&Service::stop) >= 0), bool> {
        return true;
    }

    // Fallback in case Service::stop doesn't exist.
    template<typename>
    static constexpr auto check(...) -> bool {
        return false;
    }
};
```
This was presumably written before the introduction of concepts in C++/Seastar, but that doesn't really matter. To enforce this rule in Rust, we simply use a trait:
```rs
pub trait Service {
    fn stop(&self) -> Box<dyn Future<Output = ()>> {
        Box::new(async {})
    }
}
```

## `Distributed`'s methods 
While `Distributed` exposes the `start_single`, `start` and `stop` methods, which are equivalent to their C++ counterparts, other methods differ slightly. That is the case for:
- `distributed::map`,
- `distributed::invoke_on_others`,
- `distributed::invoke_on`.

While `distributed::map_reduce` and `distributed::map_reduce0` are not exposed to avoid redundancy - we can just expose some mapping functions, and the user of the API can reduce its results by hand with the addition of a single method call (either `reduce` or `fold` from the `Iterator` trait).

But back to the aforementioned list - what is actually exposed is:
- `Distributed::map_all` - *almost* equivalent to `distributed::map`,
- `Distributed::map_others` - *almost* equivalent to `distributed::invoke_on_others` but can handle futures of a return type other than void/unit,
- `Distributed::map_single` - equivalent to `distributed::invoke_on` but, like above, handles all sorts of types.

The reason for diverging from the original methods was to provide a more powerful API. Because the original methods are not transferred directly, the new functions are implemented using `submit_to` (if I recall correctly, the C++ methods make use of it as well).  

The reason for writing "*almost*" in the above list is that due to each call of `submit_to` yielding a future, `map_all` and `map_others` return `Vec<impl Future>`. This change too leads to more flexibility, as the API user can decide for themselves whether they want to squash the futures together using something like `futures::future::join_all` or wait for merely a subset of them.

## A small dependency

The total number of shards, as well as the current one, must be known in order to delegate work to a subset of shards. Because of this, I added a new module in `smp.rs` that exposes functions for precisely that:
- `this_shard_id` - returns the id of the current shard,
- `get_count` - returns the total number of shards.

This may come in handy in some future features as well.
