### PR TITLE
logger: add Rust interface to seastar loggers

### DIFF
--- a/seastar/Cargo.toml
+++ b/seastar/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "1.0.38"
 paste = "1.0.11"
 
 [dev-dependencies]
+ctor = "0.1.26"
 num_cpus = "1.15.0"
 rand = "0.7.3"
 

--- a/seastar/build.rs
+++ b/seastar/build.rs
@@ -12,6 +12,7 @@ static CXX_BRIDGES: &[&str] = &[
     "src/smp.rs",
     "src/distributed.rs",
     "src/file.rs",
+    "src/logger.rs",
 ];
 
 static CXX_CPP_SOURCES: &[&str] = &[
@@ -26,6 +27,7 @@ static CXX_CPP_SOURCES: &[&str] = &[
     "src/smp.cc",
     "src/distributed.cc",
     "src/file.cc",
+    "src/logger.cc",
 ];
 
 fn main() {

--- a/seastar/examples/logging.rs
+++ b/seastar/examples/logging.rs
@@ -1,0 +1,31 @@
+use seastar::{submit_to, AppTemplate, Logger, Options};
+
+#[ctor::ctor]
+static MLOGGER: Logger = Logger::new("main");
+
+#[ctor::ctor]
+static CSLOGGER: Logger = Logger::new("cross-shard");
+
+pub fn main() {
+    let opts = Options::default();
+    let shard_count = opts.get_smp();
+    let mut template = AppTemplate::new_from_options(opts);
+    template.run_void(std::env::args(), async move {
+        seastar::info!(MLOGGER, "Starting application!");
+
+        let futs = (0..shard_count)
+            .map(|shard_id| {
+                submit_to(shard_id, move || async move {
+                    seastar::info!(CSLOGGER, "Hello from shard {}!", shard_id);
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for fut in futs {
+            fut.await;
+        }
+
+        seastar::info!(MLOGGER, "Stopping application!");
+        Ok(())
+    });
+}

--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -11,6 +11,8 @@ mod distributed;
 mod ffi_utils;
 mod file;
 mod gate;
+mod logger;
+
 mod preempt;
 #[doc(hidden)]
 pub mod seastar_test_guard;
@@ -29,6 +31,7 @@ pub use config_and_start_seastar::*;
 pub use distributed::*;
 pub use file::*;
 pub use gate::*;
+pub use logger::*;
 pub use preempt::*;
 pub use sleep::*;
 pub use smp::*;

--- a/seastar/src/logger.cc
+++ b/seastar/src/logger.cc
@@ -1,0 +1,28 @@
+#include <algorithm>
+
+#include "logger.hh"
+#include "seastar/src/logger.rs.h"
+
+namespace seastar_ffi {
+namespace logger {
+
+std::unique_ptr<logger> new_logger(rust::Str name) {
+    auto sname = seastar::sstring(name.data(), name.size());
+    return std::make_unique<logger>(std::move(sname));
+}
+
+void log(const logger& l, uint32_t level, const FormatCtx& ctx) noexcept {
+    seastar::logger::lambda_log_writer writer_wrapper([&] (auto it) {
+        log_writer writer{std::move(it)};
+        write_log_line(writer, ctx);
+        return std::move(writer.it);
+    });
+    const_cast<logger&>(l).log((seastar::log_level)level, writer_wrapper);
+}
+
+void log_writer::write(rust::Slice<const uint8_t> data) noexcept {
+    it = std::copy(data.begin(), data.end(), std::move(it));
+}
+
+}
+}

--- a/seastar/src/logger.hh
+++ b/seastar/src/logger.hh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+#include <cstdint>
+#include <seastar/util/log.hh>
+
+#include "rust/cxx.h"
+
+namespace seastar_ffi {
+namespace logger {
+
+using logger = seastar::logger;
+struct FormatCtx;
+
+std::unique_ptr<logger> new_logger(rust::Str name);
+void log(const logger& l, uint32_t level, const FormatCtx& ctx) noexcept;
+
+struct log_writer {
+    seastar::internal::log_buf::inserter_iterator it;
+    void write(rust::Slice<const uint8_t> data) noexcept;
+};
+
+}
+}

--- a/seastar/src/logger.rs
+++ b/seastar/src/logger.rs
@@ -1,0 +1,248 @@
+use std::fmt::Arguments;
+use std::pin::Pin;
+
+use cxx::UniquePtr;
+
+#[cxx::bridge(namespace = "seastar_ffi::logger")]
+mod ffi {
+    extern "Rust" {
+        type FormatCtx<'a>;
+        fn write_log_line(writer: Pin<&mut log_writer>, ctx: &FormatCtx<'_>);
+    }
+
+    unsafe extern "C++" {
+        include!("seastar/src/logger.hh");
+
+        type log_writer;
+        fn write(self: Pin<&mut log_writer>, data: &[u8]);
+
+        type logger;
+        fn new_logger(name: &str) -> UniquePtr<logger>;
+        fn log(l: &logger, level: u32, ctx: &FormatCtx<'_>);
+    }
+}
+
+/// Internal, do not use.
+// For some reason, cxx requires this to be public.
+#[doc(hidden)]
+pub struct FormatCtx<'a> {
+    args: Arguments<'a>,
+}
+
+fn write_log_line(writer: Pin<&mut ffi::log_writer>, ctx: &FormatCtx<'_>) {
+    struct FmtWriter<'a>(Pin<&'a mut ffi::log_writer>);
+    impl<'a> std::fmt::Write for FmtWriter<'a> {
+        fn write_str(&mut self, s: &str) -> std::fmt::Result {
+            self.0.as_mut().write(s.as_bytes());
+            Ok(())
+        }
+    }
+
+    std::fmt::write(&mut FmtWriter(writer), ctx.args).unwrap();
+}
+
+/// Log verbosity level.
+#[repr(u32)]
+pub enum LogLevel {
+    Error = 0,
+    Warn = 1,
+    Info = 2,
+    Debug = 3,
+    Trace = 4,
+}
+
+/// A wrapper over seastar::logger.
+///
+/// # Usage
+///
+/// Customarily, seastar loggers are created on a per-module basis. Rust doesn't
+/// support non-const constructors for static globals, but you can use
+/// the [`ctor`] crate to achieve this:
+///
+/// ```rust
+/// use ctor::ctor;
+/// use seastar::Logger;
+///
+/// #[ctor]
+/// static LOGGER: Logger = Logger::new("my_logger");
+/// ```
+///
+/// Printing messages is done with the help of Rust's formatting infrastructure.
+/// There are five main macros, one for each log level:
+/// [`error!`](crate::error!), [`warn!`](crate::warn!), [`info!`](crate::info!),
+/// [`debug!`](crate::debug!) and [`trace!`](crate::trace!). They take
+/// a logger as a first argument and then the rest of the arguments is the same
+/// as for e.g. the [`println!`](std::println!) macro.
+///
+/// ```rust
+/// # use seastar::Logger;
+/// # fn compile_only() {
+/// let logger = Logger::new("my_logger");
+/// seastar::trace!(logger, "Some verbose stuff");
+/// seastar::info!(logger, "The answer is: {}", 42);
+/// # }
+/// ```
+pub struct Logger {
+    core: UniquePtr<ffi::logger>,
+}
+
+unsafe impl Send for Logger {}
+unsafe impl Sync for Logger {}
+
+impl Logger {
+    /// Creates a new seastar logger with given name.
+    ///
+    /// # Example
+    ///
+    /// In C++, seastar loggers are usually declared as static global variables.
+    /// They register themselves in a global registry before the main function
+    /// runs, allowing the application to obtain information about available
+    /// loggers at any point, set the verbosity level etc.
+    ///
+    /// Rust doesn't support non-const constructors for static variables
+    /// out of the box, but they can be introduced with the `ctor` crate.
+    ///
+    /// ```rust
+    /// # use ctor::ctor;
+    /// # use seastar::Logger;
+    /// #[ctor]
+    /// static LOGGER: Logger = Logger::new("my_logger");
+    ///
+    /// async fn do_stuff() {
+    ///     seastar::info!(LOGGER, "Doing stuff...");
+    /// }
+    /// ```
+    #[inline]
+    pub fn new(name: &str) -> Self {
+        Self {
+            core: ffi::new_logger(name),
+        }
+    }
+
+    /// Emits a message with requested level.
+    ///
+    /// While it's possible to use directly, you will most likely be
+    /// interested in the [`log!`](crate::log!) macro instead.
+    #[inline]
+    pub fn log(&self, level: LogLevel, args: Arguments<'_>) {
+        let ctx = FormatCtx { args };
+        ffi::log(&self.core, level as u32, &ctx);
+    }
+
+    /// Emits a `trace` level message.
+    ///
+    /// While it's possible to use directly, you will most likely be
+    /// interested in the [`trace!`](crate::trace!) macro instead.
+    #[inline]
+    pub fn trace(&self, args: Arguments<'_>) {
+        self.log(LogLevel::Trace, args);
+    }
+
+    /// Emits a `debug` level message.
+    ///
+    /// While it's possible to use directly, you will most likely be
+    /// interested in the [`debug!`](crate::debug!) macro instead.
+    #[inline]
+    pub fn debug(&self, args: Arguments<'_>) {
+        self.log(LogLevel::Debug, args);
+    }
+
+    /// Emits a `info` level message.
+    ///
+    /// While it's possible to use directly, you will most likely be
+    /// interested in the [`info!`](crate::info!) macro instead.
+    #[inline]
+    pub fn info(&self, args: Arguments<'_>) {
+        self.log(LogLevel::Info, args);
+    }
+
+    /// Emits a `warn` level message.
+    ///
+    /// While it's possible to use directly, you will most likely be
+    /// interested in the [`warn!`](crate::warn!) macro instead.
+    #[inline]
+    pub fn warn(&self, args: Arguments<'_>) {
+        self.log(LogLevel::Warn, args);
+    }
+
+    /// Emits a `error` level message.
+    ///
+    /// While it's possible to use directly, you will most likely be
+    /// interested in the [`error!`](crate::error!) macro instead.
+    #[inline]
+    pub fn error(&self, args: Arguments<'_>) {
+        self.log(LogLevel::Error, args);
+    }
+}
+
+/// Emits a formatted log message with given logger.
+///
+/// The arguments to the macro are as follows:
+/// - `logger` - reference to the [`Logger`] to be used,
+/// - `level` - [`LogLevel`] to use,
+/// - `arg...` - arguments, as if passed to the [`std::format!`] macro.
+///
+/// # Example
+/// ```rust
+/// # use seastar::{Logger, LogLevel};
+/// # fn compile_only() {
+/// let logger = Logger::new("my_logger");
+/// seastar::log!(logger, LogLevel::Info, "Hello, {}!", "world");
+/// # }
+/// ```
+#[macro_export]
+macro_rules! log {
+    ($logger:expr, $level:expr, $($arg:tt),*) => {{
+        $logger.log($level, std::format_args!($($arg),*))
+    }};
+}
+
+/// Emits a formatted log message with `trace` level.
+///
+/// Equivalent to calling [`log!`](crate::log!) with `trace` level.
+#[macro_export]
+macro_rules! trace {
+    ($logger:expr, $($arg:tt),*) => {{
+        $logger.trace(std::format_args!($($arg),*))
+    }};
+}
+
+/// Emits a `debug` level message with given logger.
+///
+/// Equivalent to calling [`log!`](crate::log!) with `debug` level.
+#[macro_export]
+macro_rules! debug {
+    ($logger:expr, $($arg:tt),*) => {{
+        $logger.debug(std::format_args!($($arg),*))
+    }};
+}
+
+/// Emits a `info` level message with given logger.
+///
+/// Equivalent to calling [`log!`](crate::log!) with `info` level.
+#[macro_export]
+macro_rules! info {
+    ($logger:expr, $($arg:tt),*) => {{
+        $logger.info(std::format_args!($($arg),*))
+    }};
+}
+
+/// Emits a `warn` level message with given logger.
+///
+/// Equivalent to calling [`log!`](crate::log!) with `warn` level.
+#[macro_export]
+macro_rules! warn {
+    ($logger:expr, $($arg:tt),*) => {{
+        $logger.warn(std::format_args!($($arg),*))
+    }};
+}
+
+/// Emits an `error` level message with given logger.
+///
+/// Equivalent to calling [`log!`](crate::log!) with `error` level.
+#[macro_export]
+macro_rules! error {
+    ($logger:expr, $($arg:tt),*) => {{
+        $logger.error(std::format_args!($($arg),*))
+    }};
+}


### PR DESCRIPTION
Adds an API that wraps seastar loggers.

A logger can be instantiated on stack, but it can also be defined globally, with the help of the `ctor` crate:

    #[ctor::ctor]
    static MLOGGER: Logger = Logger::new("main");

Log messages can be printed with the help of macros that follow a syntax similar to `println!` and its friends:

    seastar::info!(MLOGGER, "Going to frobnicate {} blubs", num_blubs);