### PR TITLE
Make seastar_test_guard::acquire_guard_for_seastar_test public

### DIFF
--- a/seastar/src/lib.rs
+++ b/seastar/src/lib.rs
@@ -10,14 +10,14 @@ mod cxx_async_local_future;
 mod ffi_utils;
 mod gate;
 mod preempt;
-#[cfg(test)]
-pub(crate) mod seastar_test_guard;
+#[doc(hidden)]
+pub mod seastar_test_guard;
 mod sleep;
 mod spawn;
 mod submit_to;
 
-#[cfg(test)]
-pub(crate) use seastar_test_guard::acquire_guard_for_seastar_test;
+#[doc(hidden)]
+pub use seastar_test_guard::acquire_guard_for_seastar_test;
 
 pub use api_safety::*;
 pub use clocks::*;

--- a/seastar/src/seastar_test_guard.rs
+++ b/seastar/src/seastar_test_guard.rs
@@ -2,7 +2,7 @@ use std::sync::{Mutex, MutexGuard};
 
 static RUNNING_TEST_WITH_SEASTAR: Mutex<()> = Mutex::new(());
 
-pub(crate) struct RunningTestWithSeastarGuard(MutexGuard<'static, ()>);
+pub struct RunningTestWithSeastarGuard(MutexGuard<'static, ()>);
 
 /// Acquires a global mutex for the purpose of running a test with the
 /// seastar runtime.
@@ -15,7 +15,7 @@ pub(crate) struct RunningTestWithSeastarGuard(MutexGuard<'static, ()>);
 ///
 /// The mutex should be taken by all tests that create a seastar runtime
 /// and held until the test finishes.
-pub(crate) fn acquire_guard_for_seastar_test() -> RunningTestWithSeastarGuard {
+pub fn acquire_guard_for_seastar_test() -> RunningTestWithSeastarGuard {
     // If a test panics, we assume that the runtime has been stopped
     // properly in that test, so we can ignore that the lock is poisoned.
     let guard = RUNNING_TEST_WITH_SEASTAR


### PR DESCRIPTION
This PR fixes the visibility of `seastar_test_guard::acquire_guard_for_seastar_test` from `pub(crate)` to `pub`. After this change, it is possible to use macro `seastar::test` outside of the crate, previously there was an error like that: `cannot find function acquire_guard_for_seastar_test in crate seastar`.