### PR TITLE
key-value store example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
     "seastar",
     "seastar-macros",
+    "examples/key-value-store",
 ]

--- a/examples/key-value-store/Cargo.toml
+++ b/examples/key-value-store/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "key-value-store"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cxx = "1"
+cxx-async = { git = "https://github.com/kfernandez31/cxx-async", branch = "seastar" }
+seastar = { path = "../../seastar" }
+
+[build-dependencies]
+cxx-build = { version = "1", features = ["parallel"] }
+pkg-config = "0.3"

--- a/examples/key-value-store/Cargo.toml
+++ b/examples/key-value-store/Cargo.toml
@@ -8,6 +8,7 @@ cxx = "1"
 cxx-async = { git = "https://github.com/kfernandez31/cxx-async", branch = "seastar" }
 seastar = { path = "../../seastar" }
 regex = "1"
+futures = "0.3.25"
 
 [build-dependencies]
 cxx-build = { version = "1", features = ["parallel"] }

--- a/examples/key-value-store/Cargo.toml
+++ b/examples/key-value-store/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 cxx = "1"
 cxx-async = { git = "https://github.com/kfernandez31/cxx-async", branch = "seastar" }
 seastar = { path = "../../seastar" }
+regex = "1"
 
 [build-dependencies]
 cxx-build = { version = "1", features = ["parallel"] }

--- a/examples/key-value-store/README.md
+++ b/examples/key-value-store/README.md
@@ -1,0 +1,57 @@
+# key-value store
+
+This crate is an example of using the crate `seastar-rs`. Its two main objectives are:
+1. To demonstrate how to use some of Seastar's functionalities exposed by `seastar-rs` from C++ to Rust. This example covers [`seastar::main`](https://github.com/zpp-2022-rust-seastar/seastar-rs/blob/main/seastar-macros/src/lib.rs) macro and [`seastar::Distributed<S>`](https://github.com/zpp-2022-rust-seastar/seastar-rs/blob/main/seastar/src/distributed.rs).
+2. To show how to integrate the code written using `seastar-rs `with the already existing C++ code. In this example, a part of Seastar's network API is exposed to Rust using the `cxx` crate and integrated with the rest of the Rust code.
+
+## Use
+
+To run this example, execute the following command in the `seastar-rs` directory:
+```
+RUSTFLAGS="-C link-arg=-fuse-ld=lld" RUSTDOCFLAGS="-C link-arg=-fuse-ld=lld" cargo run --bin key-value-store
+```
+
+If you work on a machine with more than 30 cores, running the example can end up in a deadlock due to a bug in the `cxx-async` crate. In such a case, the `taskset` command might help. For instance, you could run the example using 16 cores like this:
+
+```
+RUSTFLAGS="-C link-arg=-fuse-ld=lld" RUSTDOCFLAGS="-C link-arg=-fuse-ld=lld" taskset -c 0-15 cargo run --bin key-value-store
+```
+
+If you want to connect to the server, you could use `netcat`:
+```
+nc <address> 5555
+```
+
+## Server
+
+This example is an implementation of a simple key-value store server. The server accepts TCP connections on port 5555 and serves client requests. Each request is an ASCII string.
+
+### Requests
+
+The server accepts two kinds of requests - STORE and LOAD.
+
+STORE requests:
+  - have a form `STORE$key$value\n` where `key` and `value` can be a string of any length (even empty) containing only lowercase letters of the English alphabet,
+  - after receiving such a request, the server puts `value` under `key` in its memoty,
+  - if `key` is already present in the server's memory, `value` overwrites the old value,
+  - the server responds with `DONE\n`.
+
+LOAD requests:
+  - have a form `LOAD$key\n` where `key` can be a string of any length containing only lowercase letters of the English alphabet,
+  - after receiving such a request, if `key` is present in the server's memory, the server sends a reposone of a form `FOUND$value\n` where `value` is the value under `key`,
+  - if `key` is not present in the server's memory, the server sends a response `NOTFOUND\n`.
+
+If the server receives an incorrect request, it closes the connection with the client. More precisely, this happens when a message sent by the client cannot become a correct STORE or LOAD request, no matter what the client sends in the future.
+
+### Internals
+
+Understanding the server's logic might be helpful when reading the code. In short, the server works like this:
+- The server is distributed on all shards. To achieve this, it uses `seastar::Distributed<S>`.
+- Every shard owns a key-value store called `db` responsible for a part of the keys. The `db` on shard `s` stores key `k` if and only if `hash(k) % num_shards = s` where `hash` is a hashing function.
+- All shards are listening concurrently on port 5555.
+- After accepting a new client, the server spawns an independent `handle_connection` task on the same shard using `seastar::Distributed<S>::map_current`. This task is not `await`ed since we do not want to stop a listening loop for a single client. The task continues until an error occurs, the client disconnects, or the client sends an incorrect message.
+- To perform a STORE or LOAD request, the server spawns a new task on a shard that owns `db` responsible for this request's key. Communication between shards is possible thanks to `seastar::PeeringShardedService<'a, S>`.
+- When the server processes a message sent by a client, 3 cases are possible:
+  - The message contains a prefix (perhaps equal to the whole message) that is a proper request. In this case, the server handles the request in the way described above and continues processing the message after removing the request from it.
+  - The message does not contain a prefix being a complete request, but such a prefix may appear when the client sends new characters. Examples of such a message could be `STORE$key$va` and `LOA`. In this case, the server waits for future characters.
+  - The message does not contain a prefix being a complete request, and it is impossible that such a prefix will appear in the future no matter what the client sends. Examples of such a message could be `STORE$key$@`, `LOAD$Key` and `STTORE`. In this case, the server closes the connection with the client.

--- a/examples/key-value-store/build.rs
+++ b/examples/key-value-store/build.rs
@@ -1,0 +1,24 @@
+fn main() {
+    let seastar = pkg_config::Config::new()
+        .statik(true)
+        .probe("seastar")
+        .unwrap();
+
+    pkg_config::Config::new().statik(true).probe("fmt").unwrap();
+
+    let mut build = cxx_build::bridge("src/net_ffi.rs");
+    for (var, value) in &seastar.defines {
+        match value {
+            Some(val) => build.define(var, val.as_str()),
+            None => build.define(var, None),
+        };
+    }
+    build
+        .flag_if_supported("-Wall")
+        .flag_if_supported("-std=c++20")
+        .flag_if_supported("-fcoroutines")
+        .includes(&seastar.include_paths)
+        .cpp_link_stdlib("stdc++")
+        .file("src/net_ffi.cc")
+        .compile("key-value-store");
+}

--- a/examples/key-value-store/src/lib.rs
+++ b/examples/key-value-store/src/lib.rs
@@ -1,2 +1,8 @@
 mod net_ffi;
 pub use net_ffi::*;
+
+mod requests;
+pub use requests::*;
+
+mod server;
+pub use server::*;

--- a/examples/key-value-store/src/lib.rs
+++ b/examples/key-value-store/src/lib.rs
@@ -1,0 +1,2 @@
+mod net_ffi;
+pub use net_ffi::*;

--- a/examples/key-value-store/src/main.rs
+++ b/examples/key-value-store/src/main.rs
@@ -1,0 +1,2 @@
+#[seastar::main]
+async fn main() {}

--- a/examples/key-value-store/src/main.rs
+++ b/examples/key-value-store/src/main.rs
@@ -1,2 +1,9 @@
+use key_value_store::*;
+
 #[seastar::main]
-async fn main() {}
+async fn main() {
+    let distr = seastar::Distributed::start(Server::new).await;
+    let futs = distr.map_all(|sharded| ShardedServer(sharded).run(5555));
+    futures::future::join_all(futs).await;
+    distr.stop().await;
+}

--- a/examples/key-value-store/src/net_ffi.cc
+++ b/examples/key-value-store/src/net_ffi.cc
@@ -2,4 +2,57 @@
 
 namespace net_ffi {
 
+std::unique_ptr<server_socket> listen(uint16_t port) {
+    seastar::socket_address address(0, port);
+
+    seastar::listen_options options;
+    options.proto = seastar::transport::TCP;
+    options.reuse_address = true;
+
+    server_socket socket = seastar::listen(address, options);
+    return std::make_unique<server_socket>(std::move(socket));
+}
+
+VoidFuture accept(
+    const std::unique_ptr<server_socket>& server_socket,
+    std::unique_ptr<connected_socket>& socket
+) {
+    seastar::accept_result result = co_await server_socket->accept();
+    socket = std::make_unique<connected_socket>(std::move(result.connection));
+}
+
+std::unique_ptr<input_stream> get_input_stream(
+    const std::unique_ptr<connected_socket>& socket
+) {
+    input_stream input = socket->input();
+    return std::make_unique<input_stream>(std::move(input));
+}
+
+std::unique_ptr<output_stream> get_output_stream(
+    const std::unique_ptr<connected_socket>& socket
+) {
+    output_stream output = socket->output();
+    return std::make_unique<output_stream>(std::move(output));
+}
+
+VoidFuture close_output_stream(const std::unique_ptr<output_stream>& output) {
+    co_await output->close();
+}
+
+StringFuture read(const std::unique_ptr<input_stream>& input) {
+    auto buffer = co_await input->read();
+    co_return rust::String(buffer.begin(), buffer.size());
+}
+
+VoidFuture write(
+    const std::unique_ptr<output_stream>& output,
+    const rust::str msg
+) {
+    co_await output->write(seastar::sstring(msg.begin(), msg.size()));
+}
+
+VoidFuture flush_output(const std::unique_ptr<output_stream>& output) {
+    co_await output->flush();
+}
+
 } // namespace net_ffi

--- a/examples/key-value-store/src/net_ffi.cc
+++ b/examples/key-value-store/src/net_ffi.cc
@@ -1,0 +1,5 @@
+#include "net_ffi.hh"
+
+namespace net_ffi {
+
+} // namespace net_ffi

--- a/examples/key-value-store/src/net_ffi.hh
+++ b/examples/key-value-store/src/net_ffi.hh
@@ -1,5 +1,46 @@
 #pragma once
 
+#include "rust/cxx.h"
+#include "cxx-async/include/rust/cxx_async.h"
+#include "cxx-async/include/rust/cxx_async_seastar.h"
+#include <seastar/net/api.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/coroutine.hh>
+
+CXXASYNC_DEFINE_FUTURE(void, net_ffi, VoidFuture);
+CXXASYNC_DEFINE_FUTURE(rust::String, net_ffi, StringFuture);
+
 namespace net_ffi {
+
+using seastar::server_socket;
+using seastar::connected_socket;
+using input_stream = seastar::input_stream<char>;
+using output_stream = seastar::output_stream<char>;
+
+std::unique_ptr<server_socket> listen(uint16_t port);
+
+VoidFuture accept(
+    const std::unique_ptr<server_socket>& server_socket,
+    std::unique_ptr<connected_socket>& socket
+);
+
+std::unique_ptr<input_stream> get_input_stream(
+    const std::unique_ptr<connected_socket>& socket
+);
+
+std::unique_ptr<output_stream> get_output_stream(
+    const std::unique_ptr<connected_socket>& socket
+);
+
+VoidFuture close_output_stream(const std::unique_ptr<output_stream>& output);
+
+StringFuture read(const std::unique_ptr<input_stream>& input);
+
+VoidFuture write(
+    const std::unique_ptr<output_stream>& output,
+    const rust::str msg
+);
+
+VoidFuture flush_output(const std::unique_ptr<output_stream>& output);
 
 } // namespace net_ffi

--- a/examples/key-value-store/src/net_ffi.hh
+++ b/examples/key-value-store/src/net_ffi.hh
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace net_ffi {
+
+} // namespace net_ffi

--- a/examples/key-value-store/src/net_ffi.rs
+++ b/examples/key-value-store/src/net_ffi.rs
@@ -1,0 +1,6 @@
+#[cxx::bridge(namespace = "net_ffi")]
+mod ffi {
+    unsafe extern "C++" {
+        include!("key-value-store/src/net_ffi.hh");
+    }
+}

--- a/examples/key-value-store/src/net_ffi.rs
+++ b/examples/key-value-store/src/net_ffi.rs
@@ -1,6 +1,66 @@
+use cxx::UniquePtr;
+use std::future::Future;
+
 #[cxx::bridge(namespace = "net_ffi")]
 mod ffi {
     unsafe extern "C++" {
         include!("key-value-store/src/net_ffi.hh");
+
+        type VoidFuture = crate::VoidFuture;
+        type StringFuture = crate::StringFuture;
+
+        #[rust_name = "ServerSocket"]
+        type server_socket;
+
+        #[rust_name = "ConnectedSocket"]
+        type connected_socket;
+
+        #[rust_name = "InputStream"]
+        type input_stream;
+
+        #[rust_name = "OutputStream"]
+        type output_stream;
+
+        fn listen(port: u16) -> UniquePtr<ServerSocket>;
+
+        fn accept(
+            server_socket: &UniquePtr<ServerSocket>,
+            socket: &mut UniquePtr<ConnectedSocket>,
+        ) -> VoidFuture;
+
+        fn get_input_stream(socket: &UniquePtr<ConnectedSocket>) -> UniquePtr<InputStream>;
+
+        fn get_output_stream(socket: &UniquePtr<ConnectedSocket>) -> UniquePtr<OutputStream>;
+
+        fn close_output_stream(socket: &UniquePtr<OutputStream>) -> VoidFuture;
+
+        fn read(socket: &UniquePtr<InputStream>) -> StringFuture;
+
+        fn write(socket: &UniquePtr<OutputStream>, msg: &str) -> VoidFuture;
+
+        fn flush_output(socket: &UniquePtr<OutputStream>) -> VoidFuture;
     }
+}
+
+#[cxx_async::bridge(namespace = net_ffi)]
+unsafe impl Future for VoidFuture {
+    type Output = ();
+}
+
+#[cxx_async::bridge(namespace = net_ffi)]
+unsafe impl Future for StringFuture {
+    type Output = String;
+}
+
+pub use ffi::{
+    close_output_stream, flush_output, get_input_stream, get_output_stream, listen, read, write,
+    ConnectedSocket, InputStream, OutputStream, ServerSocket,
+};
+
+pub async fn accept(
+    server_socket: &UniquePtr<ServerSocket>,
+) -> Result<UniquePtr<ConnectedSocket>, cxx_async::CxxAsyncException> {
+    let mut socket = UniquePtr::null();
+    ffi::accept(server_socket, &mut socket).await?;
+    Ok(socket)
 }

--- a/examples/key-value-store/src/requests.rs
+++ b/examples/key-value-store/src/requests.rs
@@ -1,0 +1,111 @@
+use super::server::{ConnectionError, ConnectionResult};
+use regex::Regex;
+
+pub enum Request {
+    Store(StoreRequest),
+    Load(LoadRequest),
+}
+
+pub struct StoreRequest {
+    pub key: String,
+    pub value: String,
+}
+
+impl StoreRequest {
+    pub fn new(key: String, value: String) -> Self {
+        StoreRequest { key, value }
+    }
+}
+
+pub struct LoadRequest {
+    pub key: String,
+}
+
+impl LoadRequest {
+    pub fn new(key: String) -> Self {
+        LoadRequest { key }
+    }
+}
+
+static STORE: &str = "STORE$";
+static LOAD: &str = "LOAD$";
+
+fn match_regex(message: &str, pattern: &str) -> ConnectionResult<bool> {
+    match Regex::new(pattern) {
+        Ok(regex) => Ok(regex.is_match(message)),
+        Err(_) => Err(ConnectionError),
+    }
+}
+
+// Returns true if there exists a prefix of a message parameter
+// that is a correct STORE request.
+fn is_store_request(message: &str) -> ConnectionResult<bool> {
+    match_regex(message, r#"^STORE\$[a-z]*\$[a-z]*\n"#)
+}
+
+// Returns true if there exists a prefix of a message parameter
+// that is a correct LOAD request.
+fn is_load_request(message: &str) -> ConnectionResult<bool> {
+    match_regex(message, r#"^LOAD\$[a-z]*\n"#)
+}
+
+// Returns true if message could become a correct STORE request
+// after appending more chars.
+fn could_become_store_request(message: &str) -> ConnectionResult<bool> {
+    if message.len() <= STORE.len() {
+        return Ok(message == &STORE[..message.len()]);
+    }
+
+    Ok(match_regex(message, r"^STORE\$[a-z]*$")?
+        || match_regex(message, r"^STORE\$[a-z]*\$[a-z]*$")?)
+}
+
+// Returns true if message could become a correct LOAD request
+// after appending more chars.
+fn could_become_load_request(message: &str) -> ConnectionResult<bool> {
+    if message.len() <= LOAD.len() {
+        return Ok(message == &LOAD[..message.len()]);
+    }
+
+    match_regex(message, r"^LOAD\$[a-z]*$")
+}
+
+// Splits a message with a prefix that is a correct STORE request
+// from STORE$key$value\nrest to (key, value, rest).
+fn split_store_request(message: &str) -> (String, String, String) {
+    let message = &message[STORE.len()..];
+    let dollar = message.find('$').unwrap();
+    let newline = message.find('\n').unwrap();
+    let key = message[..dollar].to_string();
+    let value = message[dollar + 1..newline].to_string();
+    let rest = message[newline + 1..].to_string();
+    (key, value, rest)
+}
+
+// Splits a message with a prefix that is a correct LOAD request
+// from LOAD$key\nrest to (key, rest).
+fn split_load_request(message: &str) -> (String, String) {
+    let newline = message.find('\n').unwrap();
+    let key = message[LOAD.len()..newline].to_string();
+    let rest = message[newline + 1..].to_string();
+    (key, rest)
+}
+
+// If a message contains a prefix that is a correct request, returns
+// Some(request). If the message is incorrect, returns ConnectionError.
+// Otherwise, returns None. Removes the request part from the message.
+pub fn try_parse_request(message: &mut String) -> ConnectionResult<Option<Request>> {
+    if is_store_request(message)? {
+        let (key, value, rest) = split_store_request(message);
+        *message = rest;
+        Ok(Some(Request::Store(StoreRequest::new(key, value))))
+    } else if is_load_request(message)? {
+        let (key, rest) = split_load_request(message);
+        *message = rest;
+        Ok(Some(Request::Load(LoadRequest::new(key))))
+    } else if could_become_store_request(message)? || could_become_load_request(message)? {
+        Ok(None)
+    } else {
+        Err(ConnectionError)
+    }
+}

--- a/examples/key-value-store/src/server.rs
+++ b/examples/key-value-store/src/server.rs
@@ -1,3 +1,10 @@
+use super::*;
+use cxx::UniquePtr;
+use std::cell::RefCell;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
 // An error returned when something fails while handling requests.
 // We do not care what really happened because in every case we just
 // close the connection with the client.
@@ -5,3 +12,150 @@
 pub struct ConnectionError;
 
 pub type ConnectionResult<T> = Result<T, ConnectionError>;
+
+pub struct Connection {
+    _socket: UniquePtr<ConnectedSocket>,
+    input: UniquePtr<InputStream>,
+    output: UniquePtr<OutputStream>,
+    message: String, // Unprocessed fragment of the message.
+}
+
+impl Connection {
+    fn new(
+        _socket: UniquePtr<ConnectedSocket>,
+        input: UniquePtr<InputStream>,
+        output: UniquePtr<OutputStream>,
+    ) -> Self {
+        Self {
+            _socket,
+            input,
+            output,
+            message: String::new(),
+        }
+    }
+}
+
+pub struct Server {
+    db: RefCell<HashMap<String, String>>,
+}
+
+impl Server {
+    pub fn new() -> Self {
+        Server {
+            db: RefCell::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for Server {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl seastar::Service for Server {}
+
+pub struct ShardedServer<'a>(pub seastar::PeeringShardedService<'a, Server>);
+
+impl ShardedServer<'_> {
+    #[allow(unused_must_use)]
+    pub async fn run(self, port: u16) {
+        let listener = listen(port);
+
+        loop {
+            if let Ok(socket) = accept(&listener).await {
+                self.0.container.map_current(|sharded| async move {
+                    let input = get_input_stream(&socket);
+                    let output = get_output_stream(&socket);
+                    Self(sharded)
+                        .handle_connection(Connection::new(socket, input, output))
+                        .await;
+                });
+            }
+        }
+    }
+
+    async fn handle_connection(self, mut conn: Connection) {
+        loop {
+            match read(&conn.input).await {
+                Err(_) => break,
+                Ok(buffer) if buffer.is_empty() => break,
+                Ok(buffer) => {
+                    buffer.chars().for_each(|c| conn.message.push(c));
+
+                    if self.process_message(&mut conn).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+
+        let _ = close_output_stream(&conn.output).await;
+    }
+
+    // Processes message until it has no prefix being a complete STORE or LOAD request.
+    // Returns ConnectionError, if message is for sure incorrect.
+    async fn process_message(&self, conn: &mut Connection) -> ConnectionResult<()> {
+        loop {
+            match try_parse_request(&mut conn.message) {
+                Err(_) => return Err(ConnectionError),
+                Ok(None) => return Ok(()),
+                Ok(Some(Request::Store(req))) => self.process_store_request(conn, req).await?,
+                Ok(Some(Request::Load(req))) => self.process_load_request(conn, req).await?,
+            }
+        }
+    }
+
+    async fn process_store_request(
+        &self,
+        conn: &Connection,
+        req: StoreRequest,
+    ) -> ConnectionResult<()> {
+        let storage_id = Self::get_storing_shard_id(&req.key);
+        self.0
+            .container
+            .map_single(storage_id, |sharded| async move {
+                let mut db = sharded.instance.db.borrow_mut();
+                db.insert(req.key, req.value);
+            })
+            .await;
+
+        self.respond(conn, "DONE\n").await
+    }
+
+    async fn process_load_request(
+        &self,
+        conn: &Connection,
+        req: LoadRequest,
+    ) -> ConnectionResult<()> {
+        let storage_id = Self::get_storing_shard_id(&req.key);
+        let load_result = self
+            .0
+            .container
+            .map_single(storage_id, |sharded| async move {
+                let db = sharded.instance.db.borrow();
+                db.get(&req.key).cloned()
+            })
+            .await;
+
+        match load_result {
+            None => self.respond(conn, "NOTFOUND\n").await,
+            Some(val) => self.respond(conn, format!("FOUND${val}\n").as_str()).await,
+        }
+    }
+
+    async fn respond(&self, conn: &Connection, message: &str) -> ConnectionResult<()> {
+        write(&conn.output, message)
+            .await
+            .map_err(|_| ConnectionError)?;
+        flush_output(&conn.output)
+            .await
+            .map_err(|_| ConnectionError)
+    }
+
+    fn get_storing_shard_id(key: &String) -> u32 {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        hasher.finish() as u32 % seastar::get_count()
+    }
+}

--- a/examples/key-value-store/src/server.rs
+++ b/examples/key-value-store/src/server.rs
@@ -1,0 +1,7 @@
+// An error returned when something fails while handling requests.
+// We do not care what really happened because in every case we just
+// close the connection with the client.
+#[derive(Debug)]
+pub struct ConnectionError;
+
+pub type ConnectionResult<T> = Result<T, ConnectionError>;

--- a/seastar/src/timer.rs
+++ b/seastar/src/timer.rs
@@ -205,7 +205,7 @@ impl<ClockType: Clock> Timer<ClockType> {
             return None;
         }
 
-        return Some(Instant::new(ClockType::get_timeout(&self.inner)));
+        Some(Instant::new(ClockType::get_timeout(&self.inner)))
     }
 }
 


### PR DESCRIPTION
Depends on #46

This PR introduces a key-value store demo of `seaster-rs`.

The description is in `seastar-rs/examples/key-value-store/README.md`. I think describing this demo is a good idea because reading its code is one of the primary ways for users to learn how to use our crate. That's why I have written a quite precise README file.

I would like to point out some technical issues regarding the demo and its development:
- When I was trying to use `seastar::Distributed<S>`, it turned out that some things must be fixed or improved there. @kfernandez31 made all improvements necessary to make the example work, but he has not finished yet. He will make a new PR when he finishes. So the first three commits of this PR containing his changes should not be discussed here.
- For now the field `db` of the struct `Server` has type`RefCell<HashMap<String, String>>`. `RefCell` is necessary because `seastar::Distributed<S>::map_single` requires a const reference of the service. If this changes, I will remove `RefCell`.
- The two issues described above are the reason I marked this PR as a draft. Some parts of `seastar::Distributed<S>` can change and it will affect this PR.
- The example is a completely separate crate because `build.rs` is necessary. If I'm not wrong, it's impossible to create such examples in the `seastar/examples` directory.
- Currently, `listen` calls ending with an error are not handled in Rust. Underlying `seastar::listen` ends the program with a stack trace. It happens, for example, if port 5555 is already in use. I'm not sure if we should handle it in a different way.
- The whole `requests` module is almost an exact copy-paste from the [Tokio server](https://github.com/patjed41/key-value-store/blob/master/src/request_parsing.rs) done by me at the beginning of the ZPP. It has already passed a review and unit tests so I think it is safe to assume that it just works.