### PR TITLE
Improvements for Distributed

### DIFF
--- a/seastar/src/distributed.rs
+++ b/seastar/src/distributed.rs
@@ -111,6 +111,8 @@ impl<S: Service> Distributed<S> {
     where
         Func: Fn() -> S + Sync,
     {
+        crate::assert_runtime_is_running();
+
         let stop_caller = get_stop_caller::<S>();
         let dropper = get_dropper_noarg::<S>();
 
@@ -259,6 +261,7 @@ impl<S: Service> Distributed<S> {
     /// }
     /// ```
     pub async fn stop(&self) {
+        crate::assert_runtime_is_running();
         ffi::stop(self._inner.as_ref().unwrap()).await.unwrap();
     }
 
@@ -273,6 +276,8 @@ impl<S: Service> Distributed<S> {
         Ret: Send + 'static,
         I: IntoIterator<Item = u32>,
     {
+        crate::assert_runtime_is_running();
+
         shards
             .into_iter()
             .map(|shard| (shard, func.clone(), self._inner.clone()))

--- a/seastar/src/ffi_utils.rs
+++ b/seastar/src/ffi_utils.rs
@@ -66,3 +66,20 @@ pub const fn get_dropper_const<T>(_: &T) -> fn(*const u8) {
 pub const fn get_dropper_noarg<T>() -> fn(*mut u8) {
     dropper::<T>
 }
+
+/// A wrapper over a raw pointer that makes it passable between threads.
+/// Use this only if you know what you're doing.
+pub struct PtrWrapper(*mut u8);
+
+impl PtrWrapper {
+    pub unsafe fn new(ptr: *mut u8) -> Self {
+        PtrWrapper(ptr)
+    }
+
+    pub unsafe fn as_ptr_mut(&self) -> *mut u8 {
+        self.0
+    }
+}
+
+unsafe impl Send for PtrWrapper {}
+unsafe impl Sync for PtrWrapper {}


### PR DESCRIPTION
This branch introduces:
- missing safety checks (kind of a big deal),
- more types of maps for a more ergonomic API. The ones that existed before now have their `_mut` counterparts, which allow for regular mutability, instead of interior mutability. Note, however, that `stop` still requires interior mutability, should you want to alter the service's state.
- the much-awaited functionality of `peering_sharded_service`, through which instances can communicate and delegate work.